### PR TITLE
added caption input and Claude Haiku image description to upload

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -20,7 +20,7 @@ import { decode } from "base64-arraybuffer";
 import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { Alert, Image, Modal, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Alert, Image, KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView, Text, TextInput, View } from "react-native";
 import type { ImageSourcePropType } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
@@ -50,6 +50,9 @@ export default function ArchiveTab() {
   const [themeFilter, setThemeFilter] = useState<"all" | string>("all");
   const [supplementalSearchById, setSupplementalSearchById] = useState<Record<string, string>>({});
   const [selectedItem, setSelectedItem] = useState<BoardItem | null>(null);
+  const [pendingAsset, setPendingAsset] = useState<ImagePicker.ImagePickerAsset | null>(null);
+  const [captionDraft, setCaptionDraft] = useState("");
+  const [isUploading, setIsUploading] = useState(false);
 
   useEffect(() => {
     void loadSupplementalSearchText().then(setSupplementalSearchById);
@@ -163,20 +166,32 @@ export default function ArchiveTab() {
 
   const showMatchHints = searchQuery.trim().length > 0;
 
-  const handleUpload = async () => {
+  const handlePickImage = async () => {
     const fail = (msg: string) => Alert.alert("Upload", msg);
     try {
       const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
       if (!permission.granted) return fail("Please allow photo library access to upload images.");
-
       const picked = await ImagePicker.launchImageLibraryAsync({
         mediaTypes: ["images"],
         allowsEditing: false,
         quality: 1,
       });
       if (picked.canceled || !picked.assets.length) return;
+      setPendingAsset(picked.assets[0]);
+    } catch {
+      fail("Could not open photo library.");
+    }
+  };
 
-      const asset = picked.assets[0];
+  const handleConfirmUpload = async (caption: string) => {
+    if (!pendingAsset) return;
+    const asset = pendingAsset;
+    setPendingAsset(null);
+    setCaptionDraft("");
+    setIsUploading(true);
+
+    const fail = (msg: string) => Alert.alert("Upload", msg);
+    try {
       const rawName = asset.fileName || asset.uri.split("/").pop() || `upload-${Date.now()}.jpg`;
       const fileName = `${Date.now()}-${rawName.replace(/[^\w.\-]/g, "_")}`;
       const contentType = asset.mimeType ?? "image/jpeg";
@@ -186,7 +201,7 @@ export default function ArchiveTab() {
 
       const { data: memoryRow } = await supabase
         .from("memories")
-        .insert({ user_id: user.id, source: "camera_roll" })
+        .insert({ user_id: user.id, source: "camera_roll", user_caption: caption.trim() || null })
         .select("memory_id")
         .single();
       if (!memoryRow) return fail("Could not create memory record.");
@@ -243,8 +258,12 @@ export default function ArchiveTab() {
           const visionText = await placeholder_extractSearchableTextFromImage(asset.uri, {
             id: newId,
             fileName,
+            mimeType: contentType,
           });
           if (!visionText.trim()) return;
+          await supabase.from("memories")
+            .update({ ocr_description: visionText })
+            .eq("memory_id", memoryRow.memory_id);
           setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
         } catch {
           /* vision pipeline optional */
@@ -252,6 +271,8 @@ export default function ArchiveTab() {
       })();
     } catch {
       fail("Could not upload this file.");
+    } finally {
+      setIsUploading(false);
     }
   };
 
@@ -270,7 +291,7 @@ export default function ArchiveTab() {
           </View>
           <Pressable
             className="mt-4 items-center rounded-2xl bg-blue-500 px-5 py-4"
-            onPress={handleUpload}
+            onPress={() => void handlePickImage()}
           >
             <Text className="text-lg font-black text-white">Upload</Text>
           </Pressable>
@@ -290,16 +311,6 @@ export default function ArchiveTab() {
               clearButtonMode="while-editing"
             />
           </View>
-          <Text className="mt-1 text-xs text-gray-400">
-            All words must match. Stronger matches (file name, exact tags) sort first. OCR / in-image text can
-            merge into the same index — enable{" "}
-            <Text className="font-mono text-gray-500">useVisionTextExtraction</Text> in
-            teamIntegrationPlaceholders when your vision backend or native module is ready.
-          </Text>
-
-          <Text className="mt-2 text-xs font-semibold uppercase tracking-wide text-gray-400">
-            Clusters (auto from filenames)
-          </Text>
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
@@ -413,6 +424,56 @@ export default function ArchiveTab() {
               />
             ) : null}
           </Pressable>
+        </Modal>
+
+        <Modal
+          visible={!!pendingAsset}
+          transparent
+          animationType="slide"
+          onRequestClose={() => { setPendingAsset(null); setCaptionDraft(""); }}
+        >
+          <KeyboardAvoidingView behavior={Platform.OS === "ios" ? "padding" : "height"} className="flex-1">
+            <Pressable className="flex-1" onPress={() => { setPendingAsset(null); setCaptionDraft(""); }} />
+            <View className="rounded-t-3xl border-t border-gray-200 bg-white px-5 pb-10 pt-5">
+              {pendingAsset ? (
+                <Image
+                  source={{ uri: pendingAsset.uri }}
+                  style={{ width: "100%", height: 120, borderRadius: 12, marginBottom: 16 }}
+                  resizeMode="cover"
+                />
+              ) : null}
+              <Text className="mb-2 text-base font-black text-black">Add a caption</Text>
+              <View className="mb-4 rounded-2xl border border-gray-200 px-4 py-3">
+                <TextInput
+                  value={captionDraft}
+                  onChangeText={setCaptionDraft}
+                  placeholder="Optional — describe what this is…"
+                  placeholderTextColor="#9CA3AF"
+                  className="text-base text-black"
+                  multiline
+                  numberOfLines={3}
+                  autoFocus
+                />
+              </View>
+              <View className="flex-row gap-3">
+                <Pressable
+                  onPress={() => { setPendingAsset(null); setCaptionDraft(""); }}
+                  className="flex-1 items-center rounded-2xl border border-gray-200 py-4 active:opacity-70"
+                >
+                  <Text className="text-base font-black text-gray-700">Cancel</Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => void handleConfirmUpload(captionDraft)}
+                  disabled={isUploading}
+                  className="flex-1 items-center rounded-2xl bg-blue-500 py-4 active:opacity-70"
+                >
+                  <Text className="text-base font-black text-white">
+                    {isUploading ? "Uploading…" : "Upload"}
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          </KeyboardAvoidingView>
         </Modal>
       </SafeAreaView>
     </View>

--- a/lib/teamIntegrationPlaceholders.ts
+++ b/lib/teamIntegrationPlaceholders.ts
@@ -3,6 +3,7 @@
  * Flip flags in PLACEHOLDER_FLAGS to opt into behavior while implementations are WIP.
  */
 
+import * as FileSystem from "expo-file-system/legacy";
 import type { ArchiveItemMeta } from "@/lib/archiveSearchAndCluster";
 
 /** Toggle pieces of the pipeline as each teammate ships their slice. */
@@ -16,10 +17,10 @@ export const PLACEHOLDER_FLAGS = {
   /** Siya / chat: call real generative endpoint instead of canned text */
   useGenerativeChatApi: false,
   /**
-   * Vision / OCR — run after image save; text is merged into search via `searchableTextById`.
-   * Leave false until you have a backend or native pipeline (on-device OCR in Expo usually needs a dev client + native module, or a cloud Vision API).
+   * Vision / OCR — calls Claude Haiku with the image and stores the description in
+   * memories.ocr_description and the local search index.
    */
-  useVisionTextExtraction: false,
+  useVisionTextExtraction: true,
 } as const;
 
 export type ArchiveIdRef = { id: string; fileName: string };
@@ -29,7 +30,7 @@ export type ArchiveIdRef = { id: string; fileName: string };
  * Return only fields you have; empty object = keep local filename-only tags.
  */
 export async function placeholder_fetchRemoteArchiveMeta(
-  _items: ArchiveIdRef[]
+  _items: ArchiveIdRef[],
 ): Promise<Record<string, Partial<ArchiveItemMeta>>> {
   if (!PLACEHOLDER_FLAGS.useRemoteArchiveMeta) return {};
   // Example future shape:
@@ -42,7 +43,7 @@ export async function placeholder_fetchRemoteArchiveMeta(
  * Empty object = use local keyword-based `inferTheme` only.
  */
 export async function placeholder_fetchEmbeddingThemeOverrides(
-  _items: ArchiveIdRef[]
+  _items: ArchiveIdRef[],
 ): Promise<Record<string, string>> {
   if (!PLACEHOLDER_FLAGS.useEmbeddingThemeOverrides) return {};
   return {};
@@ -51,7 +52,9 @@ export async function placeholder_fetchEmbeddingThemeOverrides(
 /**
  * TODO: Medhya — `payload` matches `archiveIndexForBackend` rows; fire-and-forget is fine.
  */
-export async function placeholder_notifyArchiveIndexUpdated(_payload: unknown): Promise<void> {
+export async function placeholder_notifyArchiveIndexUpdated(
+  _payload: unknown,
+): Promise<void> {
   if (!PLACEHOLDER_FLAGS.usePushArchiveIndex) return;
 }
 
@@ -59,7 +62,9 @@ export async function placeholder_notifyArchiveIndexUpdated(_payload: unknown): 
  * TODO: Siya — replace with fetch to your chat / completions route (body + user id + context).
  * For now returns canned copy so the Action UI can be exercised without a server.
  */
-export async function placeholder_sendChatMessage(userText: string): Promise<string> {
+export async function placeholder_sendChatMessage(
+  userText: string,
+): Promise<string> {
   if (!PLACEHOLDER_FLAGS.useGenerativeChatApi) {
     return `[Placeholder] Echo: ${userText.trim() || "(empty)"}\n\nWire useGenerativeChatApi + your API in lib/teamIntegrationPlaceholders.ts.`;
   }
@@ -69,22 +74,54 @@ export async function placeholder_sendChatMessage(userText: string): Promise<str
 export type VisionExtractContext = {
   id: string;
   fileName: string;
+  mimeType: string;
 };
 
 /**
- * TODO: Aaron / backend — OCR + optional scene / object labels from `localFileUri` (file://).
- * Return plain text only; it is folded into the same search index as filenames and tags.
- *
- * Practical options later:
- * - Server: send image to Vision API, GPT-4o/mini vision, or your embedding+caption service.
- * - Native (non–managed Expo): Apple Vision, ML Kit, etc. via config plugin / dev client.
- *
- * When `useVisionTextExtraction` is false, returns "" (no work, no cost).
+ * Sends the image to Claude Haiku and returns a plain-text description for search indexing.
+ * Result is stored in memories.ocr_description and merged into the local search blob.
  */
 export async function placeholder_extractSearchableTextFromImage(
-  _localFileUri: string,
-  _ctx: VisionExtractContext
+  localFileUri: string,
+  ctx: VisionExtractContext,
 ): Promise<string> {
   if (!PLACEHOLDER_FLAGS.useVisionTextExtraction) return "";
-  return "";
+  const apiKey = process.env.EXPO_PUBLIC_ANTHROPIC_API_KEY;
+  if (!apiKey) return "";
+  const base64 = await FileSystem.readAsStringAsync(localFileUri, {
+    encoding: FileSystem.EncodingType.Base64,
+  });
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5-20251001",
+      max_tokens: 512,
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "image",
+              source: {
+                type: "base64",
+                media_type: ctx.mimeType,
+                data: base64,
+              },
+            },
+            {
+              type: "text",
+              text: "Return a comma separated list of tags and/or description of the image",
+            },
+          ],
+        },
+      ],
+    }),
+  });
+  const json = (await res.json()) as { content?: { text?: string }[] };
+  return json.content?.[0]?.text ?? "";
 }


### PR DESCRIPTION
## Summary

When uploading a photo, a modal now appears where the user can optionally type a caption before confirming. The caption is stored in `memories.user_caption`.

After the upload completes, the image is sent to Claude Haiku, which returns a plain-text description of the photo. That description is stored in `memories.ocr_description` and also merged into the local search index so it's immediately searchable without hitting the DB again.

Fixes issue #12 

## Test plan

- [x] Tap Upload, pick an image — confirm the caption modal appears with a thumbnail and text input
- [x] Type a caption and tap Upload — confirm the upload succeeds
- [x] Check the `memories` row in Supabase and verify `user_caption` is set
- [x] Wait a few seconds and verify `ocr_description` is populated by Claude
- [x] Search the archive for a word from the description — confirm the image appears
- [x] Test Cancel — confirm no upload occurs and state is cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)