### PR TITLE
added error handling for vision description failures

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -266,8 +266,8 @@ export default function ArchiveTab() {
             .update({ ocr_description: visionText })
             .eq("memory_id", memoryRow.memory_id);
           setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
-        } catch {
-          /* vision pipeline optional */
+        } catch (err) {
+          console.warn("[vision] description extraction failed:", err);
         }
       })();
     } catch {

--- a/lib/teamIntegrationPlaceholders.ts
+++ b/lib/teamIntegrationPlaceholders.ts
@@ -122,6 +122,12 @@ export async function placeholder_extractSearchableTextFromImage(
       ],
     }),
   });
+  if (!res.ok) {
+    const errBody = (await res.json().catch(() => ({}))) as { error?: { message?: string } };
+    throw new Error(`Vision API error ${res.status}: ${errBody.error?.message ?? "unknown error"}`);
+  }
   const json = (await res.json()) as { content?: { text?: string }[] };
-  return json.content?.[0]?.text ?? "";
+  const text = json.content?.[0]?.text;
+  if (!text) throw new Error("Vision API returned no content");
+  return text;
 }


### PR DESCRIPTION
The Claude Haiku API call was missing a check for res.ok, so any failed request (bad API key, unsupported image format, rate limit, etc.) would silently return an empty string instead of surfacing the error. The catch block in archive.tsx also swallowed errors entirely, making it impossible to debug.

Changes:
- Check res.ok before parsing the response body; throw with the API's error message if the request failed
- Throw if the response parses successfully but content is missing or empty
- Log the error with console.warn in the catch block so failures are visible in the dev console

Fixes #35 