### PR TITLE
block uploads if description generation fails, resize images to fix 5MB limit

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -252,24 +252,30 @@ export default function ArchiveTab() {
       if (updateMemoryError) return fail("File uploaded but memory link failed.");
 
       const newId = `uploaded-${memoryRow.memory_id}`;
-      void loadItems();
 
-      void (async () => {
-        try {
-          const visionText = await placeholder_extractSearchableTextFromImage(asset.uri, {
-            id: newId,
-            fileName,
-            mimeType: contentType,
-          });
-          if (!visionText.trim()) return;
-          await supabase.from("memories")
-            .update({ ocr_description: visionText })
-            .eq("memory_id", memoryRow.memory_id);
-          setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
-        } catch (err) {
-          console.warn("[vision] description extraction failed:", err);
-        }
-      })();
+      const cleanupAll = async () => {
+        await supabase.storage.from("memories").remove([storagePath]);
+        await supabase.from("files").delete().eq("file_id", fileRow.file_id);
+        await cleanupMemory();
+      };
+
+      let visionText: string;
+      try {
+        visionText = await placeholder_extractSearchableTextFromImage(asset.uri, {
+          id: newId,
+          fileName,
+          mimeType: contentType,
+        });
+      } catch (err) {
+        await cleanupAll();
+        return fail(`Could not generate a description for this photo: ${err instanceof Error ? err.message : "unknown error"}`);
+      }
+
+      await supabase.from("memories")
+        .update({ ocr_description: visionText })
+        .eq("memory_id", memoryRow.memory_id);
+      setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
+      void loadItems();
     } catch {
       fail("Could not upload this file.");
     } finally {

--- a/lib/teamIntegrationPlaceholders.ts
+++ b/lib/teamIntegrationPlaceholders.ts
@@ -4,6 +4,7 @@
  */
 
 import * as FileSystem from "expo-file-system/legacy";
+import * as ImageManipulator from "expo-image-manipulator";
 import type { ArchiveItemMeta } from "@/lib/archiveSearchAndCluster";
 
 /** Toggle pieces of the pipeline as each teammate ships their slice. */
@@ -87,8 +88,15 @@ export async function placeholder_extractSearchableTextFromImage(
 ): Promise<string> {
   if (!PLACEHOLDER_FLAGS.useVisionTextExtraction) return "";
   const apiKey = process.env.EXPO_PUBLIC_ANTHROPIC_API_KEY;
-  if (!apiKey) return "";
-  const base64 = await FileSystem.readAsStringAsync(localFileUri, {
+  if (!apiKey) throw new Error("EXPO_PUBLIC_ANTHROPIC_API_KEY is not set");
+
+  // Resize to max 1568px and compress to stay under Anthropic's 5MB image limit
+  const resized = await ImageManipulator.manipulateAsync(
+    localFileUri,
+    [{ resize: { width: 1568 } }],
+    { compress: 0.8, format: ImageManipulator.SaveFormat.JPEG },
+  );
+  const base64 = await FileSystem.readAsStringAsync(resized.uri, {
     encoding: FileSystem.EncodingType.Base64,
   });
   const res = await fetch("https://api.anthropic.com/v1/messages", {

--- a/lib/teamIntegrationPlaceholders.ts
+++ b/lib/teamIntegrationPlaceholders.ts
@@ -117,7 +117,7 @@ export async function placeholder_extractSearchableTextFromImage(
               type: "image",
               source: {
                 type: "base64",
-                media_type: ctx.mimeType,
+                media_type: "image/jpeg",
                 data: base64,
               },
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
+        "expo-image-manipulator": "~14.0.8",
         "expo-image-picker": "^55.0.18",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.23",
@@ -6444,6 +6445,27 @@
       "version": "55.0.0",
       "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-55.0.0.tgz",
       "integrity": "sha512-NOjp56wDrfuA5aiNAybBIjqIn1IxKeGJ8CECWZncQ/GzjZfyTYAHTCyeApYkdKkMBLHINzI4BbTGSlbCa0fXXQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-image-manipulator/-/expo-image-manipulator-14.0.8.tgz",
+      "integrity": "sha512-sXsXjm7rIxLWZe0j2A41J/Ph53PpFJRdyzJ3EQ/qetxLUvS2m3K1sP5xy37px43qCf0l79N/i6XgFgenFV36/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~6.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-manipulator/node_modules/expo-image-loader": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-6.0.0.tgz",
+      "integrity": "sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "^55.0.18",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.23",


### PR DESCRIPTION
Two related changes to make description generation a required part of the upload flow.

The 5MB error was happening because large photos were being sent to the Anthropic API as-is. Now images are resized to a max width of 1568px and compressed to JPEG 0.8 before being sent, which keeps them well under the limit while still being high enough quality for description generation.

Description generation is now blocking. If it fails for any reason (size, API error, missing key, no content returned), the upload is rolled back — the file is removed from storage, and both the file and memory records are deleted. The user sees a specific error message explaining why it failed instead of silently getting a photo with no description.

Further fixes #35 