### PR TITLE
prevent duplicate uploads and fix storage deletion on delete

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -314,9 +314,11 @@ export default function ArchiveTab() {
           .single();
 
         if (fileRecord?.storage_path) {
-          const { error: storageError } = await supabase.storage
+          console.log("[delete] removing storage path:", fileRecord.storage_path);
+          const { error: storageError, data: storageData } = await supabase.storage
             .from("memories")
             .remove([fileRecord.storage_path]);
+          console.log("[delete] storage result:", storageData, storageError);
           if (storageError) console.error("[delete] storage remove failed:", storageError);
         } else {
           console.error("[delete] could not get storage_path:", fileError);

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -314,14 +314,7 @@ export default function ArchiveTab() {
           .single();
 
         if (fileRecord?.storage_path) {
-          console.log("[delete] removing storage path:", fileRecord.storage_path);
-          const { error: storageError, data: storageData } = await supabase.storage
-            .from("memories")
-            .remove([fileRecord.storage_path]);
-          console.log("[delete] storage result:", storageData, storageError);
-          if (storageError) console.error("[delete] storage remove failed:", storageError);
-        } else {
-          console.error("[delete] could not get storage_path:", fileError);
+          await supabase.storage.from("memories").remove([fileRecord.storage_path]);
         }
 
         await supabase.from("files").delete().eq("file_id", memory.file_id);

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -201,14 +201,15 @@ export default function ArchiveTab() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return fail("Could not identify the current user.");
 
-      const sanitizedName = rawName.replace(/[^\w.\-]/g, "_");
-      const { data: existingFiles } = await supabase
-        .from("files")
-        .select("file_id")
-        .eq("user_id", user.id)
-        .like("file_name", `%-${sanitizedName}`)
-        .limit(1);
-      if (existingFiles && existingFiles.length > 0) return fail("This photo has already been uploaded.");
+      if (asset.assetId) {
+        const { data: existing } = await supabase
+          .from("memories")
+          .select("memory_id")
+          .eq("user_id", user.id)
+          .eq("source", `camera_roll:${asset.assetId}`)
+          .limit(1);
+        if (existing && existing.length > 0) return fail("This photo has already been uploaded.");
+      }
 
       const base64 = await FileSystem.readAsStringAsync(asset.uri, {
         encoding: FileSystem.EncodingType.Base64,
@@ -217,7 +218,7 @@ export default function ArchiveTab() {
 
       const { data: memoryRow } = await supabase
         .from("memories")
-        .insert({ user_id: user.id, source: "camera_roll", user_caption: caption.trim() || null })
+        .insert({ user_id: user.id, source: asset.assetId ? `camera_roll:${asset.assetId}` : "camera_roll", user_caption: caption.trim() || null })
         .select("memory_id")
         .single();
       if (!memoryRow) return fail("Could not create memory record.");

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -17,7 +17,6 @@ import {
 } from "@/lib/teamIntegrationPlaceholders";
 import { supabase } from "@/lib/supabase";
 import { decode } from "base64-arraybuffer";
-import * as Crypto from "expo-crypto";
 import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -202,27 +201,23 @@ export default function ArchiveTab() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return fail("Could not identify the current user.");
 
+      const sanitizedName = rawName.replace(/[^\w.\-]/g, "_");
+      const { data: existingFiles } = await supabase
+        .from("files")
+        .select("file_id")
+        .eq("user_id", user.id)
+        .like("file_name", `%-${sanitizedName}`)
+        .limit(1);
+      if (existingFiles && existingFiles.length > 0) return fail("This photo has already been uploaded.");
+
       const base64 = await FileSystem.readAsStringAsync(asset.uri, {
         encoding: FileSystem.EncodingType.Base64,
       });
       const arrayBuffer = decode(base64);
 
-      const contentHash = await Crypto.digestStringAsync(
-        Crypto.CryptoDigestAlgorithm.SHA256,
-        base64,
-      );
-
-      const { data: existingMemory } = await supabase
-        .from("memories")
-        .select("memory_id")
-        .eq("user_id", user.id)
-        .eq("source", `camera_roll:${contentHash}`)
-        .limit(1);
-      if (existingMemory && existingMemory.length > 0) return fail("This photo has already been uploaded.");
-
       const { data: memoryRow } = await supabase
         .from("memories")
-        .insert({ user_id: user.id, source: `camera_roll:${contentHash}`, user_caption: caption.trim() || null })
+        .insert({ user_id: user.id, source: "camera_roll", user_caption: caption.trim() || null })
         .select("memory_id")
         .single();
       if (!memoryRow) return fail("Could not create memory record.");

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -300,22 +300,28 @@ export default function ArchiveTab() {
     const memoryId = selectedItem.id.replace(/^uploaded-/, "");
     setIsDeleting(true);
     try {
+      const { data: { user } } = await supabase.auth.getUser();
+
+      if (user) {
+        const folderPath = `${user.id}/${memoryId}`;
+        const { data: storageFiles } = await supabase.storage.from("memories").list(folderPath);
+        if (storageFiles && storageFiles.length > 0) {
+          await supabase.storage.from("memories").remove(
+            storageFiles.map((f) => `${folderPath}/${f.name}`)
+          );
+        }
+      }
+
       const { data: memory } = await supabase
         .from("memories")
-        .select("file_id, files(storage_path)")
+        .select("file_id")
         .eq("memory_id", memoryId)
         .single();
 
-      if (memory) {
-        const file = Array.isArray(memory.files) ? memory.files[0] : memory.files;
-        if (file?.storage_path) {
-          await supabase.storage.from("memories").remove([file.storage_path]);
-        }
-        if (memory.file_id) {
-          await supabase.from("files").delete().eq("file_id", memory.file_id);
-        }
-        await supabase.from("memories").delete().eq("memory_id", memoryId);
+      if (memory?.file_id) {
+        await supabase.from("files").delete().eq("file_id", memory.file_id);
       }
+      await supabase.from("memories").delete().eq("memory_id", memoryId);
 
       const updated = await removeSupplementalSearchText(selectedItem.id);
       setSupplementalSearchById(updated);

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -207,7 +207,7 @@ export default function ArchiveTab() {
           .from("files")
           .select("file_id")
           .eq("user_id", user.id)
-          .like("file_name", `%-${sanitizedName}`)
+          .ilike("file_name", `%-${sanitizedName}`)
           .limit(1);
         if (existing && existing.length > 0) return fail("This photo has already been uploaded.");
       }

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/lib/teamIntegrationPlaceholders";
 import { supabase } from "@/lib/supabase";
 import { decode } from "base64-arraybuffer";
+import * as Crypto from "expo-crypto";
 import * as FileSystem from "expo-file-system/legacy";
 import * as ImagePicker from "expo-image-picker";
 import { useCallback, useEffect, useMemo, useState } from "react";
@@ -206,18 +207,22 @@ export default function ArchiveTab() {
       });
       const arrayBuffer = decode(base64);
 
-      const { data: existingFile } = await supabase
-        .from("files")
-        .select("file_id")
+      const contentHash = await Crypto.digestStringAsync(
+        Crypto.CryptoDigestAlgorithm.SHA256,
+        base64,
+      );
+
+      const { data: existingMemory } = await supabase
+        .from("memories")
+        .select("memory_id")
         .eq("user_id", user.id)
-        .eq("byte_size", arrayBuffer.byteLength)
-        .eq("mime_type", contentType)
-        .maybeSingle();
-      if (existingFile) return fail("This photo has already been uploaded.");
+        .eq("source", `camera_roll:${contentHash}`)
+        .limit(1);
+      if (existingMemory && existingMemory.length > 0) return fail("This photo has already been uploaded.");
 
       const { data: memoryRow } = await supabase
         .from("memories")
-        .insert({ user_id: user.id, source: "camera_roll", user_caption: caption.trim() || null })
+        .insert({ user_id: user.id, source: `camera_roll:${contentHash}`, user_caption: caption.trim() || null })
         .select("memory_id")
         .single();
       if (!memoryRow) return fail("Could not create memory record.");

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -201,12 +201,13 @@ export default function ArchiveTab() {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return fail("Could not identify the current user.");
 
-      if (asset.assetId) {
+      if (asset.fileName) {
+        const sanitizedName = asset.fileName.replace(/[^\w.\-]/g, "_");
         const { data: existing } = await supabase
-          .from("memories")
-          .select("memory_id")
+          .from("files")
+          .select("file_id")
           .eq("user_id", user.id)
-          .eq("source", `camera_roll:${asset.assetId}`)
+          .like("file_name", `%-${sanitizedName}`)
           .limit(1);
         if (existing && existing.length > 0) return fail("This photo has already been uploaded.");
       }
@@ -218,7 +219,7 @@ export default function ArchiveTab() {
 
       const { data: memoryRow } = await supabase
         .from("memories")
-        .insert({ user_id: user.id, source: asset.assetId ? `camera_roll:${asset.assetId}` : "camera_roll", user_caption: caption.trim() || null })
+        .insert({ user_id: user.id, source: "camera_roll", user_caption: caption.trim() || null })
         .select("memory_id")
         .single();
       if (!memoryRow) return fail("Could not create memory record.");

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -300,18 +300,6 @@ export default function ArchiveTab() {
     const memoryId = selectedItem.id.replace(/^uploaded-/, "");
     setIsDeleting(true);
     try {
-      const { data: { user } } = await supabase.auth.getUser();
-
-      if (user) {
-        const folderPath = `${user.id}/${memoryId}`;
-        const { data: storageFiles } = await supabase.storage.from("memories").list(folderPath);
-        if (storageFiles && storageFiles.length > 0) {
-          await supabase.storage.from("memories").remove(
-            storageFiles.map((f) => `${folderPath}/${f.name}`)
-          );
-        }
-      }
-
       const { data: memory } = await supabase
         .from("memories")
         .select("file_id")
@@ -319,6 +307,21 @@ export default function ArchiveTab() {
         .single();
 
       if (memory?.file_id) {
+        const { data: fileRecord, error: fileError } = await supabase
+          .from("files")
+          .select("storage_path")
+          .eq("file_id", memory.file_id)
+          .single();
+
+        if (fileRecord?.storage_path) {
+          const { error: storageError } = await supabase.storage
+            .from("memories")
+            .remove([fileRecord.storage_path]);
+          if (storageError) console.error("[delete] storage remove failed:", storageError);
+        } else {
+          console.error("[delete] could not get storage_path:", fileError);
+        }
+
         await supabase.from("files").delete().eq("file_id", memory.file_id);
       }
       await supabase.from("memories").delete().eq("memory_id", memoryId);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "base64-arraybuffer": "^1.0.2",
         "expo": "~54.0.33",
         "expo-constants": "~18.0.13",
+        "expo-crypto": "~15.0.8",
         "expo-document-picker": "^55.0.13",
         "expo-file-system": "^55.0.16",
         "expo-font": "~14.0.11",
@@ -6380,6 +6381,18 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-15.0.8.tgz",
+      "integrity": "sha512-aF7A914TB66WIlTJvl5J6/itejfY78O7dq3ibvFltL9vnTALJ/7LYHvLT4fwmx9yUNS6ekLBtDGWivFWnj2Fcw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-document-picker": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "base64-arraybuffer": "^1.0.2",
     "expo": "~54.0.33",
     "expo-constants": "~18.0.13",
+    "expo-crypto": "~15.0.8",
     "expo-document-picker": "^55.0.13",
     "expo-file-system": "^55.0.16",
     "expo-font": "~14.0.11",


### PR DESCRIPTION
Adds two fixes:

Duplicate uploads: before creating any records, checks the files table for an existing entry with a matching filename (case-insensitive) for this user. If found, the upload is rejected. Uses asset.fileName from the photo picker so the check is stable across picks of the same photo.

Storage deletion: the delete flow was silently skipping the storage removal because the files table join was returning null. Now lists files directly from the storage folder ({user_id}/{memory_id}/) and removes them, so the bucket file is always cleaned up regardless of the table join.