### PR TITLE
Action tab configured now to produce itenaries/bucket list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 # Optional: Anthropic (Claude Haiku) for auto image descriptions / tags on upload (see lib/teamIntegrationPlaceholders.ts)
 # EXPO_PUBLIC_ANTHROPIC_API_KEY=
 
-# Optional: OpenAI — use only after wiring code to read process.env.EXPO_PUBLIC_OPENAI_API_KEY (not used in repo by default)
+# OpenAI API key for Action chat responses using memories.ocr_description context
 # EXPO_PUBLIC_OPENAI_API_KEY=

--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -21,7 +21,7 @@ export default function ActionTab() {
   const [messages, setMessages] = useState<ChatMessage[]>([
     {
       role: "assistant",
-      text: "Placeholder chat — connect `placeholder_sendChatMessage` to your API in lib/teamIntegrationPlaceholders.ts.",
+      text: "I can help plan from your uploaded memories. Try one of the quick actions below.",
     },
   ]);
   const [sending, setSending] = useState(false);
@@ -35,12 +35,15 @@ export default function ActionTab() {
     try {
       const reply = await placeholder_sendChatMessage(trimmed);
       setMessages((m) => [...m, { role: "assistant", text: reply }]);
-    } catch {
+    } catch (err) {
       setMessages((m) => [
         ...m,
         {
           role: "assistant",
-          text: "[Placeholder] Chat request failed — add error handling when you integrate the real API.",
+          text:
+            err instanceof Error
+              ? `Sorry, I could not generate a response: ${err.message}`
+              : "Sorry, I could not generate a response right now.",
         },
       ]);
     } finally {
@@ -62,7 +65,7 @@ export default function ActionTab() {
           <Text className="px-5 pt-2 text-sm font-medium text-[#5F5F5F]">Assistant</Text>
           <Text className="px-5 pt-1 text-4xl font-bold tracking-[-0.5px] text-[#0B0B0B]">Action</Text>
           <Text className="px-5 pb-2 pt-1 text-xs font-medium uppercase tracking-[0.2em] text-[#6B6B6B]">
-            Placeholder
+            Memory-aware assistant
           </Text>
 
           <ScrollView

--- a/lib/chatPromptPlaceholders.ts
+++ b/lib/chatPromptPlaceholders.ts
@@ -5,5 +5,4 @@
 export const PLACEHOLDER_CHAT_PROMPTS = [
   "Create a bucket list for this weekend",
   "Draft a short weekend itinerary",
-  "Write a profile blurb from my saved interests",
 ] as const;

--- a/lib/teamIntegrationPlaceholders.ts
+++ b/lib/teamIntegrationPlaceholders.ts
@@ -6,6 +6,7 @@
 import * as FileSystem from "expo-file-system/legacy";
 import * as ImageManipulator from "expo-image-manipulator";
 import type { ArchiveItemMeta } from "@/lib/archiveSearchAndCluster";
+import { supabase } from "@/lib/supabase";
 
 /** Toggle pieces of the pipeline as each teammate ships their slice. */
 export const PLACEHOLDER_FLAGS = {
@@ -16,7 +17,7 @@ export const PLACEHOLDER_FLAGS = {
   /** Optional: POST archive index snapshot after local index changes */
   usePushArchiveIndex: false,
   /** Siya / chat: call real generative endpoint instead of canned text */
-  useGenerativeChatApi: false,
+  useGenerativeChatApi: true,
   /**
    * Vision / OCR — calls Claude Haiku with the image and stores the description in
    * memories.ocr_description and the local search index.
@@ -67,9 +68,87 @@ export async function placeholder_sendChatMessage(
   userText: string,
 ): Promise<string> {
   if (!PLACEHOLDER_FLAGS.useGenerativeChatApi) {
-    return `[Placeholder] Echo: ${userText.trim() || "(empty)"}\n\nWire useGenerativeChatApi + your API in lib/teamIntegrationPlaceholders.ts.`;
+    return `Echo: ${userText.trim() || "(empty)"}`;
   }
-  return userText;
+  const apiKey = process.env.EXPO_PUBLIC_OPENAI_API_KEY?.trim();
+  if (!apiKey) {
+    throw new Error(
+      "Missing EXPO_PUBLIC_OPENAI_API_KEY. Add it to your .env and restart Expo."
+    );
+  }
+
+  const { data: auth } = await supabase.auth.getUser();
+  const userId = auth.user?.id;
+  if (!userId) {
+    throw new Error("You need to sign in before using chat.");
+  }
+
+  const { data: memoryRows, error: memoryError } = await supabase
+    .from("memories")
+    .select("ocr_description")
+    .eq("user_id", userId)
+    .not("ocr_description", "is", null)
+    .order("memory_id", { ascending: false })
+    .limit(80);
+
+  if (memoryError) {
+    throw new Error(`Could not load memory context: ${memoryError.message}`);
+  }
+
+  const descriptions = (memoryRows ?? [])
+    .map((row) => row.ocr_description?.trim())
+    .filter((text): text is string => Boolean(text));
+
+  const memoryContext =
+    descriptions.length > 0
+      ? descriptions.map((d, i) => `${i + 1}. ${d}`).join("\n")
+      : "No OCR descriptions are available yet.";
+
+  const systemPrompt =
+    "You are a planning assistant for the user's saved memories.\n" +
+    "Use ONLY the provided OCR memory descriptions as grounding context.\n" +
+    "When asked for a bucket list or itinerary, synthesize ideas from those memories.\n" +
+    "If context is sparse, say so and provide a best-effort draft.";
+
+  const response = await fetch("https://api.openai.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "gpt-4.1-mini",
+      temperature: 0.7,
+      messages: [
+        { role: "system", content: systemPrompt },
+        {
+          role: "user",
+          content:
+            `OCR memory descriptions:\n${memoryContext}\n\n` +
+            `User request: ${userText.trim()}`,
+        },
+      ],
+    }),
+  });
+
+  if (!response.ok) {
+    const errBody = (await response.json().catch(() => ({}))) as {
+      error?: { message?: string };
+    };
+    throw new Error(
+      `OpenAI chat error ${response.status}: ${errBody.error?.message ?? "unknown error"}`
+    );
+  }
+
+  const json = (await response.json()) as {
+    choices?: { message?: { content?: string } }[];
+  };
+  const content = json.choices?.[0]?.message?.content?.trim();
+  if (!content) {
+    throw new Error("OpenAI returned an empty response.");
+  }
+
+  return content;
 }
 
 export type VisionExtractContext = {


### PR DESCRIPTION
- Replaces Action tab placeholder chat with a real OpenAI-backed chat flow.
- Grounds chat responses in the user’s uploaded memory context by reading memories.ocr_description from Supabase.
- Keeps the quick actions focused on the two planning prompts: bucket list and weekend itinerary.
- Removes placeholder UI copy and improves runtime error messaging for missing API key / auth / API failures.
- Documents OpenAI env usage in .env.example.