### PR TITLE
added PostHog analytics for KPI tracking

### DIFF
--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -1,4 +1,5 @@
 import { PLACEHOLDER_CHAT_PROMPTS } from "@/lib/chatPromptPlaceholders";
+import { posthog } from "@/lib/posthog";
 import { placeholder_sendChatMessage } from "@/lib/teamIntegrationPlaceholders";
 import { Ionicons } from "@expo/vector-icons";
 import { useCallback, useRef, useState } from "react";
@@ -27,6 +28,8 @@ export default function ActionTab() {
   const [sending, setSending] = useState(false);
   const [showQuickActions, setShowQuickActions] = useState(true);
   const scrollRef = useRef<ScrollView>(null);
+  // stable session ID for grouping messages in PostHog
+  const chatSessionId = useRef(`chat-${Date.now()}`).current;
 
   const appendExchange = useCallback(async (userText: string) => {
     const trimmed = userText.trim();
@@ -34,6 +37,7 @@ export default function ActionTab() {
     setShowQuickActions(false);
     setSending(true);
     setMessages((m) => [...m, { role: "user", text: trimmed }]);
+    posthog.capture("chat_message_sent", { chat_session_id: chatSessionId });
     try {
       const reply = await placeholder_sendChatMessage(trimmed);
       setMessages((m) => [...m, { role: "assistant", text: reply }]);

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -15,6 +15,7 @@ import {
   placeholder_fetchRemoteArchiveMeta,
   placeholder_notifyArchiveIndexUpdated,
 } from "@/lib/teamIntegrationPlaceholders";
+import { posthog } from "@/lib/posthog";
 import { supabase } from "@/lib/supabase";
 import { useFocusEffect } from "@react-navigation/native";
 import { decode } from "base64-arraybuffer";
@@ -379,6 +380,7 @@ export default function ArchiveTab() {
         return fail("Upload succeeded but could not save OCR description.");
       }
       setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
+      posthog.capture("photo_uploaded");
       void loadItems();
     } catch {
       fail("Could not upload this file.");

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,18 @@
 import { Stack } from "expo-router";
 import { AuthProvider } from "@/lib/auth";
+import { posthog } from "@/lib/posthog";
+import { PostHogProvider } from "posthog-react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import "../global.css";
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
-      <AuthProvider>
-        <Stack screenOptions={{ headerShown: false }} />
-      </AuthProvider>
+      <PostHogProvider client={posthog}>
+        <AuthProvider>
+          <Stack screenOptions={{ headerShown: false }} />
+        </AuthProvider>
+      </PostHogProvider>
     </SafeAreaProvider>
   );
 }

--- a/lib/auth.tsx
+++ b/lib/auth.tsx
@@ -1,3 +1,4 @@
+import { posthog } from "@/lib/posthog";
 import { supabase } from "@/lib/supabase";
 import type { Session } from "@supabase/supabase-js";
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
@@ -28,6 +29,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const { data: listener } = supabase.auth.onAuthStateChange((_event, nextSession) => {
       setSession(nextSession);
       setIsLoading(false);
+      if (nextSession?.user) {
+        posthog.identify(nextSession.user.id, { email: nextSession.user.email });
+      } else {
+        posthog.reset();
+      }
     });
 
     return () => {

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -1,0 +1,5 @@
+import PostHog from "posthog-react-native";
+
+export const posthog = new PostHog("phc_CAVtoZaoaBZybq73E6eWqwn8DPMHVxv29XqgBNkVCYjQ", {
+  host: "https://us.i.posthog.com",
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "expo-system-ui": "~6.0.9",
         "expo-web-browser": "~15.0.10",
         "nativewind": "^4.2.3",
+        "posthog-react-native": "^4.43.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -2657,6 +2658,21 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@posthog/core": {
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.27.1.tgz",
+      "integrity": "sha512-130F5zAmGoY0KAqdT2FYfU79mk54z0wTWfCMkyzXmkKz2eg23694O2ofaAf4NuIdI8e6LFNHyaZ7aWbatUeW5A==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.371.2"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.371.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.371.2.tgz",
+      "integrity": "sha512-Ak3kuGMPBTjuoK6Ki0kQbq9eROk7LRJ3GBkbQINCZBT9FPlHvlXRwQr0/OVsi4xYPSMSGxWjRDMPFsR9Px66Cg==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
@@ -4780,6 +4796,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "license": "ISC",
+      "peer": true
+    },
     "node_modules/bplist-creator": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
@@ -5361,6 +5384,60 @@
         "hyphenate-style-name": "^1.0.3"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
+      "integrity": "sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.0.14",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/css-tree/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5601,6 +5678,65 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -5668,6 +5804,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-editor": {
@@ -9289,6 +9438,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
+      "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
+      "license": "CC0-1.0",
+      "peer": true
+    },
     "node_modules/memoize-one": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
@@ -9914,6 +10070,19 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "license": "BSD-2-Clause",
+      "peer": true,
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/nullthrows": {
@@ -10646,6 +10815,65 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
     },
+    "node_modules/posthog-react-native": {
+      "version": "4.43.1",
+      "resolved": "https://registry.npmjs.org/posthog-react-native/-/posthog-react-native-4.43.1.tgz",
+      "integrity": "sha512-XGBoPLErLzqQ5ohc87HMeQO/0RJl76ZN+lLBiyeFEnpqbVte46b+lWuf6E/gsmYuW99OgMYZGpq8hBfmCeWMuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.27.1",
+        "@posthog/types": "1.371.2"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": ">=1.0.0",
+        "@react-navigation/native": ">= 5.0.0",
+        "expo-application": ">= 4.0.0",
+        "expo-device": ">= 4.0.0",
+        "expo-file-system": ">= 13.0.0",
+        "expo-localization": ">= 11.0.0",
+        "posthog-react-native-session-replay": ">= 1.5.4",
+        "react-native-device-info": ">= 10.0.0",
+        "react-native-localize": ">= 3.0.0",
+        "react-native-navigation": ">= 6.0.0",
+        "react-native-safe-area-context": ">= 4.0.0",
+        "react-native-svg": ">= 15.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        },
+        "@react-navigation/native": {
+          "optional": true
+        },
+        "expo-application": {
+          "optional": true
+        },
+        "expo-device": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-localization": {
+          "optional": true
+        },
+        "posthog-react-native-session-replay": {
+          "optional": true
+        },
+        "react-native-device-info": {
+          "optional": true
+        },
+        "react-native-localize": {
+          "optional": true
+        },
+        "react-native-navigation": {
+          "optional": true
+        },
+        "react-native-safe-area-context": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -11322,6 +11550,22 @@
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
         "warn-once": "^0.1.0"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-svg": {
+      "version": "15.15.4",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.4.tgz",
+      "integrity": "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "css-tree": "^1.1.3",
+        "warn-once": "0.1.1"
       },
       "peerDependencies": {
         "react": "*",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "expo-system-ui": "~6.0.9",
     "expo-web-browser": "~15.0.10",
     "nativewind": "^4.2.3",
+    "posthog-react-native": "^4.43.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",


### PR DESCRIPTION
Integrates PostHog to track our main KPIs.

Sets up a PostHog client and wraps the app in a PostHogProvider so all screens have access to analytics. Users are identified by their Supabase user ID on login and reset on logout, which lets PostHog compute DAU, time in app, and weekly returning users automatically.

Custom events tracked:
- `photo_uploaded` — fires after a successful upload in the Library tab
- `chat_message_sent` — fires on each user message in the Action tab, with a `chat_session_id` to group messages per conversation session

Fixes #43 

🤖 Generated with [Claude Code](https://claude.com/claude-code)