### PR TITLE
fix(library): index real filenames and DB text for search

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -3,12 +3,16 @@ import {
   archiveIndexForBackend,
   distinctThemes,
   enrichArchiveRows,
-  fileNameFromArchiveId,
   hydrateArchiveMeta,
   mergeArchiveMeta,
   searchAndRankArchiveRows,
 } from "@/lib/archiveSearchAndCluster";
-import { loadSupplementalSearchText, removeSupplementalSearchText, upsertSupplementalSearchText } from "@/lib/archiveSupplementalSearchText";
+import {
+  loadSupplementalSearchText,
+  mergeSupplementalStrings,
+  removeSupplementalSearchText,
+  upsertSupplementalSearchText,
+} from "@/lib/archiveSupplementalSearchText";
 import { checkImageContext, moderateUpload } from "@/lib/moderation";
 import {
   placeholder_extractSearchableTextFromImage,
@@ -51,6 +55,10 @@ type BoardItem = {
   id: string;
   source: ImageSourcePropType;
   height: number;
+  /** From `files.file_name` — used for tag/theme inference and keyword search (not raw memory UUID). */
+  searchFileName: string;
+  /** From `memories.ocr_description` + `user_caption`; merged with local supplemental OCR cache. */
+  serverSearchText: string;
 };
 
 type GridCell = {
@@ -59,7 +67,12 @@ type GridCell = {
 
 type MemoryFileRow = {
   memory_id: string;
-  files: { storage_path: string } | { storage_path: string }[] | null;
+  ocr_description: string | null;
+  user_caption: string | null;
+  files:
+    | { storage_path: string; file_name: string }
+    | { storage_path: string; file_name: string }[]
+    | null;
 };
 
 const isJpegAsset = (mimeType?: string | null, fileName?: string | null) => {
@@ -126,14 +139,25 @@ export default function ArchiveTab() {
 
     const { data } = await supabase
       .from("memories")
-      .select("memory_id, files(storage_path)")
+      .select("memory_id, ocr_description, user_caption, files(storage_path, file_name)")
       .eq("user_id", user.id)
       .not("file_id", "is", null)
       .order("memory_id", { ascending: true });
 
     const entries = ((data as MemoryFileRow[] | null) ?? []).flatMap((m) => {
       const file = Array.isArray(m.files) ? m.files[0] : m.files;
-      return file ? [{ memory_id: m.memory_id, storage_path: file.storage_path }] : [];
+      if (!file) return [];
+      const ocr = m.ocr_description?.trim() ?? "";
+      const cap = m.user_caption?.trim() ?? "";
+      const serverSearchText = [ocr, cap].filter(Boolean).join(" ");
+      return [
+        {
+          memory_id: m.memory_id,
+          storage_path: file.storage_path,
+          searchFileName: file.file_name,
+          serverSearchText,
+        },
+      ];
     });
     if (entries.length === 0) return setItems([]);
 
@@ -150,6 +174,8 @@ export default function ArchiveTab() {
               id: `uploaded-${entries[i].memory_id}`,
               source: { uri: s.signedUrl },
               height: imageHeights[i % imageHeights.length],
+              searchFileName: entries[i].searchFileName,
+              serverSearchText: entries[i].serverSearchText,
             }]
           : []
       )
@@ -183,7 +209,7 @@ export default function ArchiveTab() {
   useEffect(() => {
     const ids = items.map((item) => ({
       id: item.id,
-      fileName: fileNameFromArchiveId(item.id),
+      fileName: item.searchFileName,
     }));
 
     let cancelled = false;
@@ -202,14 +228,20 @@ export default function ArchiveTab() {
     };
   }, [items]);
 
-  const indexRows = useMemo(
-    () =>
-      enrichArchiveRows(items.map((b) => b.id), meta, {
-        themeOverrides,
-        searchableTextById: supplementalSearchById,
-      }),
-    [items, meta, themeOverrides, supplementalSearchById]
-  );
+  const indexRows = useMemo(() => {
+    const fileNameById = Object.fromEntries(items.map((b) => [b.id, b.searchFileName]));
+    const searchableTextById: Record<string, string> = { ...supplementalSearchById };
+    for (const item of items) {
+      const server = item.serverSearchText.trim();
+      if (!server) continue;
+      searchableTextById[item.id] = mergeSupplementalStrings(searchableTextById[item.id], server);
+    }
+    return enrichArchiveRows(items.map((b) => b.id), meta, {
+      themeOverrides,
+      fileNameById,
+      searchableTextById,
+    });
+  }, [items, meta, themeOverrides, supplementalSearchById]);
 
   const indexPayload = useMemo(() => archiveIndexForBackend(indexRows), [indexRows]);
 

--- a/lib/archiveSearchAndCluster.ts
+++ b/lib/archiveSearchAndCluster.ts
@@ -350,6 +350,12 @@ export type EnrichArchiveOptions = {
   /** When embeddings / backend supply a cluster label, it wins over keyword `inferTheme`. */
   themeOverrides?: Record<string, string>;
   /**
+   * Real display/storage file names keyed by archive id (e.g. from Supabase `files.file_name`).
+   * Upload ids look like `uploaded-<memory_id>`; without this, search falls back to indexing the raw
+   * UUID, which makes keyword search feel broken.
+   */
+  fileNameById?: Record<string, string>;
+  /**
    * Extra searchable text per item (captions, transcripts, OCR, notes) — folded into `searchBlob` only.
    * When you have thousands of multimodal items, populate from backend sync; ranking stays client-side until indexed.
    */
@@ -362,7 +368,8 @@ export function enrichArchiveRows(
   options?: EnrichArchiveOptions
 ): EnrichedArchiveItem[] {
   return ids.map((id) => {
-    const fileName = fileNameFromArchiveId(id);
+    const fromMap = options?.fileNameById?.[id]?.trim();
+    const fileName = fromMap && fromMap.length > 0 ? fromMap : fileNameFromArchiveId(id);
     const tags =
       meta[id]?.tags && meta[id].tags.length > 0 ? meta[id].tags : inferTagsFromFileName(fileName);
     const theme =

--- a/lib/archiveSupplementalSearchText.ts
+++ b/lib/archiveSupplementalSearchText.ts
@@ -34,14 +34,18 @@ async function writeAll(byId: Record<string, string>): Promise<void> {
   await FileSystem.writeAsStringAsync(storePath, JSON.stringify(payload));
 }
 
-function mergeChunk(prev: string | undefined, add: string): string {
+export function mergeSupplementalStrings(prev: string | undefined, add: string | undefined): string {
   const a = (prev ?? "").trim();
-  const b = add.trim();
+  const b = (add ?? "").trim();
   if (!b) return a;
   if (!a) return b;
   if (a.includes(b)) return a;
   if (b.includes(a)) return b;
   return `${a} ${b}`;
+}
+
+function mergeChunk(prev: string | undefined, add: string): string {
+  return mergeSupplementalStrings(prev, add);
 }
 
 export async function removeSupplementalSearchText(id: string): Promise<Record<string, string>> {


### PR DESCRIPTION
Search used memory UUIDs as the synthetic file name, so tags/themes and keyword matches were wrong. Supplemental OCR lived only in local JSON on first install, ignoring ocr_description and user_caption from Supabase.

- Select file_name, ocr_description, user_caption with memories
- Pass fileNameById and merge server text into enrichArchiveRows
- Export mergeSupplementalStrings for deduped local+server merge