### PR TITLE
feat(chat): add mini chat popup access on Library and Inbox

### DIFF
--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -16,6 +16,7 @@ import {
 import { checkImageContext, moderateUpload } from "@/lib/moderation";
 import { fetchRemoteArchiveMeta, notifyArchiveIndexUpdated } from "@/lib/archiveBackendSync";
 import { fetchEmbeddingThemeOverrides } from "@/lib/embeddingThemes";
+import { MiniChatWindow } from "@/components/MiniChatWindow";
 import { getWeeklyNudgeEnabled, setWeeklyNudgeEnabled } from "@/lib/nudgePrefs";
 import { extractSearchableTextFromImage } from "@/lib/vision";
 import { posthog } from "@/lib/posthog";
@@ -661,15 +662,18 @@ export default function ArchiveTab() {
               <View className="flex-row items-center justify-between">
                 <Text className="text-sm font-medium text-[#5F5F5F]">Your saves</Text>
                 {!isSelecting ? (
-                  <View ref={settingsButtonRef} collapsable={false} className="rounded-full">
-                    <Pressable
-                      accessibilityLabel="Account and settings"
-                      onPress={openSettingsMenu}
-                      hitSlop={8}
-                      className="rounded-full p-1.5 active:bg-black/5"
-                    >
-                      <Ionicons name="settings-outline" size={24} color="#2C2C2C" />
-                    </Pressable>
+                  <View className="flex-row items-center gap-1">
+                    <MiniChatWindow />
+                    <View ref={settingsButtonRef} collapsable={false} className="rounded-full">
+                      <Pressable
+                        accessibilityLabel="Account and settings"
+                        onPress={openSettingsMenu}
+                        hitSlop={8}
+                        className="rounded-full p-1.5 active:bg-black/5"
+                      >
+                        <Ionicons name="settings-outline" size={24} color="#2C2C2C" />
+                      </Pressable>
+                    </View>
                   </View>
                 ) : null}
               </View>

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -1,4 +1,5 @@
 import { MarkdownishBoldLine } from "@/components/MarkdownishBoldLine";
+import { MiniChatWindow } from "@/components/MiniChatWindow";
 import { buildTentativePlanPrompt } from "@/lib/nudgePrompt";
 import { fetchWeeklyRecap, generateWeeklyRecap } from "@/lib/weeklyRecap";
 import { utcWeekAnchorMonday } from "@/lib/weekAnchor";
@@ -101,7 +102,10 @@ export default function NotificationsTab() {
   return (
     <View className="flex-1 bg-[#F4F0EA]">
       <SafeAreaView className="flex-1 bg-[#F4F0EA]" edges={["left", "right", "bottom"]}>
-        <Text className="px-5 pt-2 text-sm font-medium text-[#5F5F5F]">Assistant</Text>
+        <View className="flex-row items-center justify-between px-5 pt-2">
+          <Text className="text-sm font-medium text-[#5F5F5F]">Assistant</Text>
+          <MiniChatWindow />
+        </View>
         <Text className="px-5 pt-1 text-4xl font-bold tracking-[-0.5px] text-[#0B0B0B]">Inbox</Text>
         <Text className="px-5 pb-2 pt-1 text-xs font-medium uppercase tracking-[0.2em] text-[#6B6B6B]">
           {subtitle}

--- a/components/MiniChatWindow.tsx
+++ b/components/MiniChatWindow.tsx
@@ -1,0 +1,206 @@
+import { sendChatMessage } from "@/lib/chat";
+import { Ionicons } from "@expo/vector-icons";
+import { useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  PanResponder,
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  useWindowDimensions,
+  View,
+} from "react-native";
+
+type ChatMessage = { role: "user" | "assistant"; text: string };
+const MINI_CHAT_STARTER_PROMPTS = [
+  "Create a bucket list for this weekend",
+  "Draft a short weekend itinerary",
+];
+
+export function MiniChatWindow() {
+  const { height: windowHeight } = useWindowDimensions();
+  const [open, setOpen] = useState(false);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [chatHeight, setChatHeight] = useState(500);
+  const scrollRef = useRef<ScrollView>(null);
+  const startHeightRef = useRef(500);
+  const minHeight = 280;
+  const maxHeight = Math.max(minHeight, windowHeight - 100);
+
+  const resizePanResponder = useRef(
+    PanResponder.create({
+      onStartShouldSetPanResponder: () => true,
+      onMoveShouldSetPanResponder: () => true,
+      onStartShouldSetPanResponderCapture: () => true,
+      onMoveShouldSetPanResponderCapture: () => true,
+      onPanResponderTerminationRequest: () => false,
+      onPanResponderGrant: () => {
+        startHeightRef.current = chatHeight;
+      },
+      onPanResponderMove: (_, gestureState) => {
+        // Drag up to increase height, drag down to decrease.
+        const nextH = Math.max(
+          minHeight,
+          Math.min(maxHeight, startHeightRef.current - gestureState.dy)
+        );
+        setChatHeight(nextH);
+      },
+    })
+  ).current;
+
+  const send = async (userText?: string) => {
+    const trimmed = (userText ?? input).trim();
+    if (!trimmed || sending) return;
+    setInput("");
+    setSending(true);
+    setMessages((m) => [...m, { role: "user", text: trimmed }]);
+    try {
+      const reply = await sendChatMessage(trimmed);
+      setMessages((m) => [...m, { role: "assistant", text: reply }]);
+    } catch (err) {
+      setMessages((m) => [
+        ...m,
+        {
+          role: "assistant",
+          text:
+            err instanceof Error
+              ? `Sorry, I could not generate a response: ${err.message}`
+              : "Sorry, I could not generate a response right now.",
+        },
+      ]);
+    } finally {
+      setSending(false);
+      requestAnimationFrame(() => scrollRef.current?.scrollToEnd({ animated: true }));
+    }
+  };
+
+  return (
+    <>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Open chat"
+        onPress={() => setOpen(true)}
+        hitSlop={8}
+        className="rounded-full p-1.5 active:bg-black/5"
+      >
+        <Ionicons name="chatbubble-ellipses-outline" size={23} color="#2C2C2C" />
+      </Pressable>
+
+      <Modal visible={open} transparent animationType="fade" onRequestClose={() => setOpen(false)}>
+        <KeyboardAvoidingView
+          className="flex-1"
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+        >
+          <Pressable className="flex-1 bg-black/30" onPress={() => setOpen(false)} />
+          <View
+            className="self-center rounded-t-3xl border-t border-[#E6E1DA] bg-[#F4F0EA]"
+            style={{ width: "94%", height: chatHeight }}
+          >
+            <View
+              className="absolute left-1/2 top-0 z-20 h-8 w-24 -translate-x-12 items-center justify-center"
+              {...resizePanResponder.panHandlers}
+            >
+              <View className="h-5 w-16 items-center justify-center rounded-full bg-black/5">
+                <View className="h-1 w-8 rounded-full bg-[#8A8278]" />
+              </View>
+            </View>
+            <View className="flex-row items-center justify-between border-b border-[#E6E1DA] px-4 py-3">
+              <Text className="text-base font-semibold text-[#0B0B0B]">Chat</Text>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Close chat"
+                onPress={() => setOpen(false)}
+                className="rounded-full p-1 active:bg-black/5"
+              >
+                <Ionicons name="close" size={22} color="#2C2C2C" />
+              </Pressable>
+            </View>
+
+            <ScrollView
+              ref={scrollRef}
+              className="flex-1 px-4 pt-3"
+              contentContainerClassName="pb-4"
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag"
+            >
+              {messages.length === 0 ? (
+                <View className="gap-3">
+                  <Text className="text-sm text-[#6B6B6B]">
+                    Ask anything about your saved memories, plans, or to-dos.
+                  </Text>
+                  <View className="flex-row flex-wrap gap-2">
+                    {MINI_CHAT_STARTER_PROMPTS.map((prompt) => (
+                      <Pressable
+                        key={prompt}
+                        onPress={() => void send(prompt)}
+                        disabled={sending}
+                        className="min-h-[64px] w-[48%] justify-center rounded-2xl border border-[#D9D2C7] bg-[#FFFCF8] px-3 py-3 active:opacity-70 disabled:opacity-40"
+                      >
+                        <Text className="text-[14px] font-semibold leading-5 text-[#0B0B0B]">
+                          {prompt}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              ) : null}
+              {messages.map((msg, i) => (
+                <View
+                  key={`${i}-${msg.role}`}
+                  className={`mb-2.5 max-w-[92%] rounded-2xl px-3.5 py-2.5 ${
+                    msg.role === "user"
+                      ? "self-end bg-[#0B0B0B]"
+                      : "self-start border border-[#E6E1DA] bg-white"
+                  }`}
+                >
+                  <Text
+                    className={`text-sm leading-5 ${msg.role === "user" ? "text-white" : "text-[#0B0B0B]"}`}
+                  >
+                    {msg.text}
+                  </Text>
+                </View>
+              ))}
+              {sending ? (
+                <View className="flex-row items-center gap-2 py-1">
+                  <ActivityIndicator size="small" color="#0B0B0B" />
+                  <Text className="text-xs text-[#5F5F5F]">Thinking...</Text>
+                </View>
+              ) : null}
+            </ScrollView>
+
+            <View className="border-t border-[#E6E1DA] bg-[#F4F0EA] px-3 pb-4 pt-3">
+              <View className="flex-row items-center gap-2">
+                <View className="min-h-[42px] flex-1 flex-row items-center rounded-full border border-[#E6E1DA] bg-[#F0EBE3] px-4">
+                  <TextInput
+                    value={input}
+                    onChangeText={setInput}
+                    placeholder="Message..."
+                    placeholderTextColor="rgba(95,95,95,0.55)"
+                    className="min-h-[36px] flex-1 text-[#0B0B0B]"
+                    editable={!sending}
+                    onSubmitEditing={() => void send()}
+                    returnKeyType="send"
+                  />
+                </View>
+                <Pressable
+                  accessibilityRole="button"
+                  onPress={() => void send()}
+                  disabled={sending || !input.trim()}
+                  className="h-9 w-9 items-center justify-center rounded-full bg-[#0B0B0B] active:opacity-80 disabled:opacity-40"
+                >
+                  <Ionicons name="send" size={16} color="#FFFFFF" />
+                </Pressable>
+              </View>
+            </View>
+          </View>
+        </KeyboardAvoidingView>
+      </Modal>
+    </>
+  );
+}


### PR DESCRIPTION
Add a top-right mini chat entrypoint on Library and Inbox with a compact popup chat window, starter prompts, and draggable height resizing so users can chat without leaving their current tab.

<img width="355" height="579" alt="Screenshot 2026-05-01 at 1 38 20 PM" src="https://github.com/user-attachments/assets/ec1b26dc-bf70-40aa-a645-b1d24aecc520" />
