### PR TITLE
removed redundant labels above Library and Action headers

### DIFF
--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -327,8 +327,7 @@ export default function ActionTab() {
       >
         <View className="flex-1 bg-[#F4F0EA]">
           <SafeAreaView className="flex-1 bg-[#F4F0EA]" edges={["left", "right", "bottom"]}>
-            <Text className="px-5 pt-2 text-sm font-medium text-[#5F5F5F]">Assistant</Text>
-            <Text className="px-5 pt-1 text-4xl font-bold tracking-[-0.5px] text-[#0B0B0B]">Action</Text>
+            <Text className="px-5 pt-2 text-4xl font-bold tracking-[-0.5px] text-[#0B0B0B]">Action</Text>
             <Text className="px-5 pb-2 pt-1 text-xs font-medium uppercase tracking-[0.2em] text-[#6B6B6B]">
               Memory-aware assistant
             </Text>

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -929,8 +929,7 @@ export default function ArchiveTab() {
         <View className="flex-1">
           <View className="px-5">
             <View className="pt-1.5">
-              <View className="flex-row items-center justify-between">
-                <Text className="text-sm font-medium text-[#5F5F5F]">Your saves</Text>
+              <View className="flex-row items-center justify-end">
                 {!isSelecting ? (
                   <View className="flex-row items-center gap-1">
                     <MiniChatWindow />


### PR DESCRIPTION
Drops the small "Your saves" caption above the Library header in the archive tab, and the "Assistant" caption above the Action header in the action tab. The big titles already say what these tabs are.

Pure JS change, reload the dev client to preview.

The notifications tab also has an "Assistant" caption — left untouched here, can do separately if we want it removed too.