### PR TITLE
added PostHog event tracking for KPIs and OKRs

### DIFF
--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -6,7 +6,7 @@ import {
   fetchRelatedMemoryThumbnails,
 } from "@/lib/fetchMemoryThumbnailUrls";
 import { CHAT_PROMPTS, sendChatMessage } from "@/lib/chat";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { removeSavedChatOutput, saveChatOutput, suggestSavedChatOutputTitle } from "@/lib/savedChatOutputs";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
@@ -137,6 +137,12 @@ export default function ActionTab() {
         const savedItem = allSaved.find((item) => item.full_text.trim() === messageText.trim());
         if (!savedItem) return;
         setSavedMessageIds((prev) => ({ ...prev, [messageId]: savedItem.id }));
+        // counts only the actual save, not an unsave
+        track("chat_response_saved", {
+          chat_session_id: chatSessionId,
+          message_id: messageId,
+          saved_id: savedItem.id,
+        });
       });
     };
     const suggested = suggestSavedChatOutputTitle(messageText);
@@ -154,7 +160,7 @@ export default function ActionTab() {
       return;
     }
     saveWithTitle(suggested);
-  }, [savedMessageIds]);
+  }, [savedMessageIds, chatSessionId]);
 
   const makeMessage = useCallback(
     (
@@ -188,7 +194,7 @@ export default function ActionTab() {
           makeMessage("user", trimmed, attachedUris.length ? attachedUris : undefined),
         ]);
       }
-      posthog.capture("chat_message_sent", {
+      track("chat_message_sent", {
         chat_session_id: chatSessionId,
         silent_handoff: silent ? 1 : 0,
         image_count: attachedUris.length,
@@ -432,7 +438,13 @@ export default function ActionTab() {
                           <Pressable
                             accessibilityRole="button"
                             accessibilityLabel="Copy chat output"
-                            onPress={() => void copyChatOutput(msg.text)}
+                            onPress={() => {
+                              track("chat_response_copied", {
+                                chat_session_id: chatSessionId,
+                                message_id: msg.id,
+                              });
+                              void copyChatOutput(msg.text);
+                            }}
                             className="flex-row items-center gap-1 rounded-full border border-[#DDD7CC] bg-[#FFFCF8] px-2.5 py-1.5 active:opacity-80"
                           >
                             <Ionicons name="copy-outline" size={14} color="#0B0B0B" />

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -19,7 +19,7 @@ import { fetchEmbeddingThemeOverrides } from "@/lib/embeddingThemes";
 import { MiniChatWindow } from "@/components/MiniChatWindow";
 import { getWeeklyNudgeEnabled, setWeeklyNudgeEnabled } from "@/lib/nudgePrefs";
 import { extractSearchableTextFromImage } from "@/lib/vision";
-import { posthog } from "@/lib/posthog";
+import { track } from "@/lib/posthog";
 import { supabase } from "@/lib/supabase";
 import { isUndefinedColumnError } from "@/lib/supabaseSchema";
 import {
@@ -381,7 +381,11 @@ export default function ArchiveTab() {
     if (archiveLoadGeneration === 0) return;
     const targetId = `uploaded-${pendingOpenMemoryId}`;
     const item = items.find((i) => i.id === targetId);
-    if (item) setSelectedItem(item);
+    if (item) {
+      setSelectedItem(item);
+      // tracks revisits-within-7d when joined with photo_uploaded in PostHog
+      track("memory_opened", { memory_id: pendingOpenMemoryId, source: "deep_link" });
+    }
     // Clear both to be safe (some callers still use openMemory).
     router.setParams({ openMemoryId: undefined, openMemory: undefined });
   }, [pendingOpenMemoryId, items, archiveLoadGeneration]);
@@ -697,7 +701,7 @@ export default function ArchiveTab() {
         return fail("Upload succeeded but could not save OCR description.");
       }
       setSupplementalSearchById(await upsertSupplementalSearchText(newId, visionText));
-      posthog.capture("photo_uploaded");
+      track("photo_uploaded", { memory_id: memoryRow.memory_id });
       void loadItems();
     } catch {
       fail("Could not upload this file.");
@@ -879,7 +883,15 @@ export default function ArchiveTab() {
     return (
       <Pressable
         key={item.id}
-        onPress={() => (isSelecting ? toggleBulkSelect(item.id) : setSelectedItem(item))}
+        onPress={() => {
+          if (isSelecting) {
+            toggleBulkSelect(item.id);
+            return;
+          }
+          setSelectedItem(item);
+          // strip "uploaded-" so the id joins with photo_uploaded payloads
+          track("memory_opened", { memory_id: item.id.replace(/^uploaded-/, ""), source: "grid" });
+        }}
         onLongPress={() => {
           if (!isSelecting) {
             setIsSelecting(true);

--- a/app/(tabs)/notifications.tsx
+++ b/app/(tabs)/notifications.tsx
@@ -13,12 +13,13 @@ import {
   updateSavedChatOutputTitle,
   type SavedChatOutput,
 } from "@/lib/savedChatOutputs";
+import { track } from "@/lib/posthog";
 import { fetchWeeklyRecap, generateWeeklyRecap } from "@/lib/weeklyRecap";
 import { utcWeekAnchorMonday } from "@/lib/weekAnchor";
 import { Ionicons } from "@expo/vector-icons";
 import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -40,6 +41,8 @@ export default function NotificationsTab() {
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [nudges, setNudges] = useState<ParsedNudgeBullet[]>([]);
+  // only fire recap_viewed once per session even if user navigates away and back
+  const recapViewedFired = useRef(false);
   const [saved, setSaved] = useState<SavedChatOutput[]>([]);
   const [selectedSaved, setSelectedSaved] = useState<SavedChatOutput | null>(null);
   const [editingSaved, setEditingSaved] = useState<SavedChatOutput | null>(null);
@@ -62,6 +65,7 @@ export default function NotificationsTab() {
   }, []);
 
   const handleDownloadSaved = useCallback((item: SavedChatOutput) => {
+    track("chat_response_shared", { saved_id: item.id });
     void exportChatTextToFile(item.title, item.full_text)
       .then(() => Alert.alert("Download", "Use the share sheet to save this to Files."))
       .catch((err) =>
@@ -111,7 +115,12 @@ export default function NotificationsTab() {
         return;
       }
       const row = await fetchWeeklyRecap(utcWeekAnchorMonday());
-      setNudges(row ? parseWeeklyRecapBullets(row.bullets) : []);
+      const parsed = row ? parseWeeklyRecapBullets(row.bullets) : [];
+      setNudges(parsed);
+      if (row && parsed.length > 0 && !recapViewedFired.current) {
+        recapViewedFired.current = true;
+        track("recap_viewed", { bullet_count: parsed.length });
+      }
       setSaved(await loadSavedChatOutputs());
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not load notifications.");
@@ -133,7 +142,12 @@ export default function NotificationsTab() {
     setError(null);
     try {
       const row = await generateWeeklyRecap();
-      setNudges(row ? parseWeeklyRecapBullets(row.bullets) : []);
+      const parsed = row ? parseWeeklyRecapBullets(row.bullets) : [];
+      setNudges(parsed);
+      if (row && parsed.length > 0 && !recapViewedFired.current) {
+        recapViewedFired.current = true;
+        track("recap_viewed", { bullet_count: parsed.length, generated: 1 });
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : "Could not generate notifications.");
     } finally {
@@ -255,12 +269,17 @@ export default function NotificationsTab() {
                               }
                               onPress={() => {
                                 if (action === "library" && nudge.memoryId) {
+                                  track("nudge_tapped", {
+                                    action: "library",
+                                    memory_id: nudge.memoryId,
+                                  });
                                   router.push({
                                     pathname: "/archive",
                                     params: { openMemoryId: nudge.memoryId },
                                   });
                                   return;
                                 }
+                                track("nudge_tapped", { action: "chat" });
                                 router.push({
                                   pathname: "/action",
                                   params: {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,14 +1,53 @@
 import { Stack } from "expo-router";
 import { AuthProvider } from "@/lib/auth";
-import { posthog } from "@/lib/posthog";
+import { posthog, resetSessionId, track } from "@/lib/posthog";
 import { PostHogProvider } from "posthog-react-native";
 import { SafeAreaProvider } from "react-native-safe-area-context";
+import { useEffect, useRef } from "react";
+import { AppState, type AppStateStatus } from "react-native";
 import "../global.css";
+
+// fires session_start / session_end so we can compute average session duration
+// and join every other event on session_id
+function SessionTracker() {
+  const sessionStartedAt = useRef<number | null>(null);
+  const appState = useRef<AppStateStatus>(AppState.currentState);
+
+  useEffect(() => {
+    // initial foreground when the app boots
+    if (appState.current === "active") {
+      resetSessionId();
+      sessionStartedAt.current = Date.now();
+      track("session_start");
+    }
+
+    const sub = AppState.addEventListener("change", (next) => {
+      const prev = appState.current;
+      appState.current = next;
+      if (prev !== "active" && next === "active") {
+        // resumed from background, start a fresh session
+        resetSessionId();
+        sessionStartedAt.current = Date.now();
+        track("session_start");
+      } else if (prev === "active" && (next === "background" || next === "inactive")) {
+        const startedAt = sessionStartedAt.current;
+        if (startedAt !== null) {
+          track("session_end", { duration_ms: Date.now() - startedAt });
+          sessionStartedAt.current = null;
+        }
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  return null;
+}
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
       <PostHogProvider client={posthog}>
+        <SessionTracker />
         <AuthProvider>
           <Stack screenOptions={{ headerShown: false }} />
         </AuthProvider>

--- a/lib/posthog.ts
+++ b/lib/posthog.ts
@@ -3,3 +3,25 @@ import PostHog from "posthog-react-native";
 export const posthog = new PostHog("phc_CAVtoZaoaBZybq73E6eWqwn8DPMHVxv29XqgBNkVCYjQ", {
   host: "https://us.i.posthog.com",
 });
+
+// session id refreshes whenever the app foregrounds. lets every event join on
+// the same session so we can compute uploads/prompts/etc per session in PostHog
+let sessionId = makeSessionId();
+
+function makeSessionId(): string {
+  return `s-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function getSessionId(): string {
+  return sessionId;
+}
+
+export function resetSessionId(): string {
+  sessionId = makeSessionId();
+  return sessionId;
+}
+
+// thin wrapper so we don't have to remember to attach session_id everywhere
+export function track(event: string, props?: Record<string, unknown>): void {
+  posthog.capture(event, { session_id: sessionId, ...(props ?? {}) });
+}


### PR DESCRIPTION
## Summary

PR for #43 #51 

Adds the PostHog events we need to measure the KPIs and objective OKR signals from the Measures for Success wiki. PostHog was already set up but only two events were firing (`photo_uploaded`, `chat_message_sent`), so most of the wiki metrics weren't computable.

## What changed

- **`lib/posthog.ts`**: new `track(event, props)` helper that auto-attaches a `session_id` to every event, plus `getSessionId()` / `resetSessionId()`.
- **`app/_layout.tsx`**: AppState listener that fires `session_start` on foreground (initial mount and each background → active) and `session_end` with `duration_ms` on background.
- **`app/(tabs)/archive.tsx`**: `memory_opened` on grid taps and `openMemoryId` deep-links. Migrated `photo_uploaded` to `track()` and added `memory_id` so revisits can join on it.
- **`app/(tabs)/action.tsx`**: `chat_response_saved` (fires only on actual save, not unsave) and `chat_response_copied` on the chat reply buttons. Migrated `chat_message_sent` to `track()`.
- **`app/(tabs)/notifications.tsx`**: `chat_response_shared` on saved-output download, `nudge_tapped` with `action` (library/chat) and `memory_id` where applicable, and `recap_viewed` fired once per session when a non-empty recap first renders.

## What this unlocks in PostHog

- Avg session duration (average of `duration_ms` on `session_end`).
- 7-day retention cohorted on `session_start`.
- Uploads / prompts per session by grouping on `session_id`.
- % uploads revisited in 7 days via `photo_uploaded → memory_opened` joined on `memory_id`.
- % chat responses → action via `chat_message_sent → chat_response_*` joined on `chat_session_id`.
- Nudge follow-through and reflection engagement.

## Out of scope

These were skipped per scoping discussion:
- Prompt-category tagging on `chat_message_sent` (itinerary vs bucket list vs general).
- In-app weekly survey for the subjective KRs.
- Link / note upload events — only photos are supported in the app today.

## Test plan

- [ ] Run the app on the simulator with PostHog Live Events open.
- [ ] Cold launch → confirm `session_start` arrives with a `session_id`.
- [ ] Background the app → confirm `session_end` with non-zero `duration_ms`.
- [ ] Reopen → confirm a new `session_start` with a fresh `session_id`.
- [ ] Upload a photo → `photo_uploaded` with `memory_id`.
- [ ] Tap a memory in the library → `memory_opened` with `memory_id` and `source: "grid"`.
- [ ] Send a chat message → `chat_message_sent`. Tap Save and Copy → `chat_response_saved` and `chat_response_copied`, both sharing the same `chat_session_id`.
- [ ] Tap a nudge from Inbox → `nudge_tapped` with the right `action`.
- [ ] First render of a non-empty recap → exactly one `recap_viewed`; revisiting the tab doesn't re-fire it in the same session.
- [ ] Tap download on a saved chat output → `chat_response_shared`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)