### PR TITLE
Added Instagram share import to the library

### DIFF
--- a/app.json
+++ b/app.json
@@ -53,13 +53,16 @@
             "enabled": true,
             "appGroupIdentifier": "group.com.cheetahspeed.Venn",
             "activationRule": {
-              "supportsImageWithMaxCount": 5
+              "supportsImageWithMaxCount": 5,
+              "supportsWebUrlWithMaxCount": 1,
+              "supportsText": true
             }
           },
           "android": {
             "enabled": true,
             "singleShareMimeTypes": [
-              "image/*"
+              "image/*",
+              "text/plain"
             ],
             "multipleShareMimeTypes": [
               "image/*"

--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -9,6 +9,7 @@ import { CHAT_PROMPTS, sendChatMessage } from "@/lib/chat";
 import { track } from "@/lib/posthog";
 import { removeSavedChatOutput, saveChatOutput, suggestSavedChatOutputTitle } from "@/lib/savedChatOutputs";
 import { Ionicons } from "@expo/vector-icons";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useFocusEffect } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
 import { useCallback, useRef, useState } from "react";
@@ -119,6 +120,9 @@ export default function ActionTab() {
   const [savedMessageIds, setSavedMessageIds] = useState<Record<string, string>>({});
   const scrollRef = useRef<ScrollView>(null);
   const chatSessionId = useRef(`chat-${Date.now()}`).current;
+  // the keyboard-avoiding view doesn't know about the tab bar, so the input ends up tucked
+  // behind the keyboard. offsetting by the tab bar height lifts it the rest of the way
+  const tabBarHeight = useBottomTabBarHeight();
 
   const handleSaveMessage = useCallback((messageId: string, messageText: string) => {
     const existingSavedId = savedMessageIds[messageId];
@@ -359,6 +363,7 @@ export default function ActionTab() {
       <KeyboardAvoidingView
         className="flex-1 bg-[#F4F0EA]"
         behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={tabBarHeight}
       >
         <View className="flex-1 bg-[#F4F0EA]">
           <SafeAreaView className="flex-1 bg-[#F4F0EA]" edges={["left", "right", "bottom"]}>

--- a/app/(tabs)/archive.tsx
+++ b/app/(tabs)/archive.tsx
@@ -13,6 +13,11 @@ import {
   upsertSupplementalSearchText,
 } from "@/lib/archiveSupplementalSearchText";
 import { extractTextTemporalSignals } from "@/lib/extractTemporalFromUserText";
+import {
+  extractInstagramUrl,
+  fetchInstagramPost,
+  isInstagramUrl,
+} from "@/lib/instagramImport";
 import { checkImageContext, moderateUpload } from "@/lib/moderation";
 import { fetchRemoteArchiveMeta, notifyArchiveIndexUpdated } from "@/lib/archiveBackendSync";
 import { fetchEmbeddingThemeOverrides } from "@/lib/embeddingThemes";
@@ -151,9 +156,17 @@ export default function ArchiveTab() {
   const [supplementalSearchById, setSupplementalSearchById] = useState<Record<string, string>>({});
   const [selectedItem, setSelectedItem] = useState<BoardItem | null>(null);
   const [pendingAsset, setPendingAsset] = useState<UploadAsset | null>(null);
+  // metadata about where a shared post came from. set when we import from instagram, cleared on confirm/cancel
+  const [pendingSourceMeta, setPendingSourceMeta] = useState<{
+    sourceUrl: string;
+    sourceAuthor: string | null;
+    sourcePlatform: string;
+  } | null>(null);
   const [captionDraft, setCaptionDraft] = useState("");
   const [intentDraft, setIntentDraft] = useState("");
   const [isUploading, setIsUploading] = useState(false);
+  // true while we're fetching a shared instagram post in the background, before the modal opens
+  const [isImportingShare, setIsImportingShare] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [isSavingCaption, setIsSavingCaption] = useState(false);
   const [viewerCaptionDraft, setViewerCaptionDraft] = useState("");
@@ -186,24 +199,86 @@ export default function ArchiveTab() {
   useEffect(() => {
     if (!resolvedSharedPayloads.length) return;
 
+    // straight image share, e.g. share from Photos. open the modal right away
     const sharedImageUris = resolvedSharedPayloads
       .filter((payload) => payload.contentType === "image" && payload.contentUri)
       .map((payload) => payload.contentUri)
       .filter((uri): uri is string => typeof uri === "string");
 
-    if (!sharedImageUris.length) return;
+    if (sharedImageUris.length > 0) {
+      const uri = sharedImageUris[0];
+      clearSharedPayloads();
+      void refreshSharePayloads();
 
-    const uri = sharedImageUris[0];
+      setPendingAsset({
+        uri,
+        fileName: uri.split("/").pop() ?? `shared-${Date.now()}.jpg`,
+        mimeType: "image/jpeg",
+      });
+      setPendingSourceMeta(null);
+      setCaptionDraft("");
+      setIntentDraft("");
+      return;
+    }
+
+    // URL / text share. instagram is the only one we know how to process today, but we still
+    // scan text shares for an instagram URL because iOS sometimes hands us "Look at this https://..."
+    const sharedUrl = (() => {
+      for (const payload of resolvedSharedPayloads) {
+        if (payload.contentType === "website" && payload.contentUri) {
+          return payload.contentUri;
+        }
+        // text payloads carry the value on the unresolved field
+        if (!payload.contentType || payload.contentType === "text") {
+          const candidate = payload.value ?? "";
+          const found = extractInstagramUrl(candidate) ?? (isInstagramUrl(candidate) ? candidate : null);
+          if (found) return found;
+        }
+      }
+      return null;
+    })();
+
+    if (!sharedUrl) return;
+
     clearSharedPayloads();
     void refreshSharePayloads();
 
-    setPendingAsset({
-      uri,
-      fileName: uri.split("/").pop() ?? `shared-${Date.now()}.jpg`,
-      mimeType: "image/jpeg",
-    });
-    setCaptionDraft("");
-    setIntentDraft("");
+    if (!isInstagramUrl(sharedUrl)) {
+      Alert.alert(
+        "Share",
+        "Venn can only import Instagram posts from a shared link right now.",
+      );
+      return;
+    }
+
+    setIsImportingShare(true);
+    void (async () => {
+      try {
+        const imported = await fetchInstagramPost(sharedUrl);
+        setPendingAsset({
+          uri: imported.localUri,
+          fileName: imported.fileName,
+          mimeType: imported.mimeType,
+        });
+        setPendingSourceMeta({
+          sourceUrl: imported.sourceUrl,
+          sourceAuthor: imported.author,
+          sourcePlatform: "instagram",
+        });
+        // pre-fill the caption with whatever IG gave us. user can edit before saving
+        setCaptionDraft(imported.caption);
+        setIntentDraft("");
+      } catch (err) {
+        Alert.alert(
+          "Instagram",
+          err instanceof Error
+            ? err.message
+            : "Could not import this Instagram post.",
+        );
+      } finally {
+        setIsImportingShare(false);
+      }
+    })();
   }, [clearSharedPayloads, refreshSharePayloads, resolvedSharedPayloads]);
 
   const loadItems = useCallback(async () => {
@@ -494,7 +569,9 @@ export default function ArchiveTab() {
     if (!pendingAsset) return;
     const asset = pendingAsset;
     const wantToDoSaved = intentDraft.trim();
+    const sourceMeta = pendingSourceMeta;
     setPendingAsset(null);
+    setPendingSourceMeta(null);
     setCaptionDraft("");
     setIntentDraft("");
     setIsUploading(true);
@@ -621,6 +698,28 @@ export default function ArchiveTab() {
           .eq("memory_id", memoryRow.memory_id);
         if (__DEV__ && intentErr && !isUndefinedColumnError(intentErr, "want_to_do")) {
           console.warn("[archive] could not save want_to_do:", intentErr.message);
+        }
+      }
+
+      // stash the IG link/author so we can show provenance later. defensive in case the migration
+      // hasn't run yet on this environment, same pattern as want_to_do above
+      if (sourceMeta) {
+        const { error: sourceErr } = await supabase
+          .from("memories")
+          .update({
+            source_url: sourceMeta.sourceUrl,
+            source_author: sourceMeta.sourceAuthor,
+            source_platform: sourceMeta.sourcePlatform,
+          })
+          .eq("memory_id", memoryRow.memory_id);
+        if (
+          __DEV__ &&
+          sourceErr &&
+          !isUndefinedColumnError(sourceErr, "source_url") &&
+          !isUndefinedColumnError(sourceErr, "source_author") &&
+          !isUndefinedColumnError(sourceErr, "source_platform")
+        ) {
+          console.warn("[archive] could not save source metadata:", sourceErr.message);
         }
       }
 
@@ -1178,11 +1277,29 @@ export default function ArchiveTab() {
         </Modal>
 
         <Modal
+          visible={isImportingShare}
+          transparent
+          animationType="fade"
+          onRequestClose={() => {
+            // user cancelled, but we can't actually abort the fetch. just hide the overlay
+            setIsImportingShare(false);
+          }}
+        >
+          <View className="flex-1 items-center justify-center bg-black/40">
+            <View className="rounded-2xl bg-white px-6 py-5">
+              <Text className="text-base font-black text-black">Importing post…</Text>
+              <Text className="mt-1 text-xs text-[#6B6B6B]">Fetching image and caption</Text>
+            </View>
+          </View>
+        </Modal>
+
+        <Modal
           visible={!!pendingAsset}
           transparent
           animationType="slide"
           onRequestClose={() => {
             setPendingAsset(null);
+            setPendingSourceMeta(null);
             setCaptionDraft("");
             setIntentDraft("");
           }}
@@ -1192,6 +1309,7 @@ export default function ArchiveTab() {
               className="flex-1"
               onPress={() => {
                 setPendingAsset(null);
+                setPendingSourceMeta(null);
                 setCaptionDraft("");
                 setIntentDraft("");
               }}
@@ -1203,6 +1321,12 @@ export default function ArchiveTab() {
                   style={{ width: "100%", height: 120, borderRadius: 12, marginBottom: 16 }}
                   contentFit="cover"
                 />
+              ) : null}
+              {pendingSourceMeta ? (
+                <Text className="mb-3 text-xs text-[#6B6B6B]">
+                  From {pendingSourceMeta.sourceAuthor ? `@${pendingSourceMeta.sourceAuthor}` : "Instagram"}
+                  {pendingSourceMeta.sourceAuthor ? " on Instagram" : ""}
+                </Text>
               ) : null}
               <Text className="mb-2 text-base font-black text-black">Add a caption</Text>
               <View className="mb-4 rounded-2xl border border-gray-200 px-4 pb-3 pt-2">
@@ -1254,6 +1378,7 @@ export default function ArchiveTab() {
                 <Pressable
                   onPress={() => {
                     setPendingAsset(null);
+                    setPendingSourceMeta(null);
                     setCaptionDraft("");
                     setIntentDraft("");
                   }}

--- a/lib/instagramImport.ts
+++ b/lib/instagramImport.ts
@@ -1,0 +1,228 @@
+// Pulls an Instagram post (or reel) into a local UploadAsset by scraping its public OG tags.
+// Runs from the client, same pattern as lib/vision.ts. No server piece needed.
+//
+// Limitations to be aware of:
+//   - IG truncates captions in og:description to roughly the first ~150 chars. Long captions
+//     are not fully recoverable without the Graph API. We surface what we can and let the user edit.
+//   - Carousels: og:image is the first slide only.
+//   - Reels: og:image is the video thumbnail. That's fine, we still get a savable image.
+//   - Private accounts / login-wall pages return a generic IG og:image and no caption. We treat
+//     that as a soft failure so the user gets a useful error.
+//   - Stories aren't shareable to third-party apps, so we never see them.
+//
+// We pretend to be a desktop browser. Instagram returns a stripped page (no og tags) when the
+// User-Agent looks like a mobile app or a known scraper.
+import * as FileSystem from "expo-file-system/legacy";
+
+export type InstagramImportResult = {
+  // local file URI ready to drop into the existing upload pipeline
+  localUri: string;
+  fileName: string;
+  mimeType: string;
+  // best-effort caption pulled from og:description (and trimmed of IG's "N likes" prefix)
+  caption: string;
+  // @handle if we could find one, otherwise null
+  author: string | null;
+  // canonical post URL, stripped of share tracking params
+  sourceUrl: string;
+};
+
+const DESKTOP_USER_AGENT =
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15";
+
+// instagram.com/p/<id>, /reel/<id>, /reels/<id>, /tv/<id> — with or without www., trailing slash, etc.
+const IG_URL_REGEX =
+  /^https?:\/\/(?:www\.|m\.)?instagram\.com\/(?:p|reel|reels|tv)\/[A-Za-z0-9_-]+/i;
+
+export function isInstagramUrl(url: string): boolean {
+  return IG_URL_REGEX.test(url.trim());
+}
+
+// Pull the post out of whatever the user shared. iOS sometimes hands us "Check this out https://..."
+// rather than the bare URL, so we hunt for the first IG URL substring.
+export function extractInstagramUrl(text: string): string | null {
+  const match = text.match(
+    /(https?:\/\/(?:www\.|m\.)?instagram\.com\/(?:p|reel|reels|tv)\/[A-Za-z0-9_-]+[^\s]*)/i,
+  );
+  return match ? match[1] : null;
+}
+
+// Strip share tracking (?igsh=, ?utm_*) and normalize trailing slash so we can dedupe later.
+function canonicalizeInstagramUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    u.search = "";
+    u.hash = "";
+    let path = u.pathname;
+    if (!path.endsWith("/")) path += "/";
+    return `https://www.instagram.com${path}`;
+  } catch {
+    return url.split("?")[0];
+  }
+}
+
+// Grab the content="..." value of a meta tag whose property/name matches `key`.
+// Cheap regex parse, no DOM available in RN.
+function readMetaTag(html: string, key: string): string | null {
+  // matches <meta property="og:image" content="..."> in either attribute order, single or double quotes
+  const patterns = [
+    new RegExp(
+      `<meta[^>]+(?:property|name)=["']${key}["'][^>]+content=["']([^"']+)["']`,
+      "i",
+    ),
+    new RegExp(
+      `<meta[^>]+content=["']([^"']+)["'][^>]+(?:property|name)=["']${key}["']`,
+      "i",
+    ),
+  ];
+  for (const re of patterns) {
+    const m = html.match(re);
+    if (m && m[1]) return decodeHtmlEntities(m[1]);
+  }
+  return null;
+}
+
+// IG escapes a bunch of stuff in og tags. RN has no DOMParser so we do this by hand.
+// Order matters: decode &amp; LAST so we don't double-decode &amp;quot; -> "
+function decodeHtmlEntities(s: string): string {
+  return (
+    s
+      // named entities we see in IG captions
+      .replace(/&quot;/g, '"')
+      .replace(/&#039;/g, "'")
+      .replace(/&apos;/g, "'")
+      .replace(/&lt;/g, "<")
+      .replace(/&gt;/g, ">")
+      .replace(/&nbsp;/g, " ")
+      .replace(/&hellip;/g, "…")
+      .replace(/&mdash;/g, "—")
+      .replace(/&ndash;/g, "–")
+      .replace(/&lsquo;/g, "‘")
+      .replace(/&rsquo;/g, "’")
+      .replace(/&ldquo;/g, "“")
+      .replace(/&rdquo;/g, "”")
+      .replace(/&trade;/g, "™")
+      .replace(/&copy;/g, "©")
+      .replace(/&reg;/g, "®")
+      // numeric entities, e.g. &#8217;  →  ’
+      .replace(/&#(\d+);/g, (_, code: string) => {
+        const n = parseInt(code, 10);
+        return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+      })
+      // hex numeric entities, e.g. &#x2019;  →  ’
+      .replace(/&#x([0-9a-fA-F]+);/g, (_, code: string) => {
+        const n = parseInt(code, 16);
+        return Number.isFinite(n) ? String.fromCodePoint(n) : "";
+      })
+      // do amp last so we don't double-decode
+      .replace(/&amp;/g, "&")
+  );
+}
+
+// Normalize a caption pulled out of IG's og:description into something that won't look weird
+// in our text input: kill invisible/zero-width chars, fix non-breaking spaces, collapse runs of
+// whitespace and blank lines, and drop the trailing "..." that IG appends when it truncates.
+function sanitizeCaption(s: string): string {
+  return (
+    s
+      // non-breaking spaces look fine until you try to select / wrap them
+      .replace(/ /g, " ")
+      // zero-width spaces / joiners / non-joiners / BOM. IG uses these for layout tricks
+      .replace(/[​-‍﻿]/g, "")
+      // strip control chars but keep \n and \t
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, "")
+      // normalize windows line endings
+      .replace(/\r\n?/g, "\n")
+      // collapse 3+ newlines down to 2 (one blank line max)
+      .replace(/\n{3,}/g, "\n\n")
+      // collapse runs of spaces/tabs
+      .replace(/[ \t]{2,}/g, " ")
+      // trim each line so trailing spaces don't show up as weird underlines in inputs
+      .split("\n")
+      .map((line) => line.trimEnd())
+      .join("\n")
+      // IG truncates around 150 chars and appends "..." or "…". the user will edit if they want
+      // more, so chop the trailing ellipsis off so the caption doesn't end mid-thought with dots
+      .replace(/[.…]+\s*$/g, "")
+      .trim()
+  );
+}
+
+// og:description looks like: `1,234 likes, 56 comments - username on October 1, 2023: "Caption..."`
+// We pull out the caption from the quoted tail when possible, and the @handle from "username on".
+function parseDescription(desc: string): { caption: string; author: string | null } {
+  // pull the quoted caption tail
+  const quoted = desc.match(/[:\-]\s*"([^"]*)"\s*\.?\s*$/);
+  // username is the word immediately before " on <date>"
+  const authorMatch = desc.match(/([A-Za-z0-9._]+)\s+on\s+[A-Z][a-z]+\s+\d{1,2},?\s+\d{4}/);
+  const rawCaption = quoted ? quoted[1] : stripLikesPrefix(desc);
+  return { caption: sanitizeCaption(rawCaption), author: authorMatch ? authorMatch[1] : null };
+}
+
+// fallback for when we can't find a quoted caption — strip the leading "N likes, M comments - "
+function stripLikesPrefix(s: string): string {
+  return s.replace(/^[\d,.\s]+likes?,\s*[\d,.\s]+comments?\s*[-–]\s*/i, "");
+}
+
+// og:title is usually `"<Display Name> (@username) on Instagram: ..."`
+function parseAuthorFromTitle(title: string): string | null {
+  const m = title.match(/\(@([A-Za-z0-9._]+)\)/);
+  return m ? m[1] : null;
+}
+
+export async function fetchInstagramPost(rawUrl: string): Promise<InstagramImportResult> {
+  const sourceUrl = canonicalizeInstagramUrl(rawUrl.trim());
+
+  // pretend to be a desktop browser, otherwise IG often returns a stripped page
+  const res = await fetch(sourceUrl, {
+    method: "GET",
+    headers: {
+      "User-Agent": DESKTOP_USER_AGENT,
+      Accept: "text/html,application/xhtml+xml",
+      "Accept-Language": "en-US,en;q=0.9",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Instagram returned HTTP ${res.status}`);
+  }
+  const html = await res.text();
+
+  const imageUrl = readMetaTag(html, "og:image");
+  if (!imageUrl) {
+    // typically means private / login-walled / removed
+    throw new Error("Could not read the post. It may be private or unavailable.");
+  }
+  const description = readMetaTag(html, "og:description") ?? "";
+  const title = readMetaTag(html, "og:title") ?? "";
+
+  const { caption, author: authorFromDesc } = parseDescription(description);
+  const author = authorFromDesc ?? parseAuthorFromTitle(title);
+
+  // pick a unique cache filename so concurrent shares don't clobber each other
+  const shortcode = sourceUrl.match(/\/(?:p|reel|reels|tv)\/([A-Za-z0-9_-]+)/)?.[1] ?? `${Date.now()}`;
+  const fileName = `instagram-${shortcode}-${Date.now()}.jpg`;
+  const cacheDir = FileSystem.cacheDirectory;
+  if (!cacheDir) throw new Error("No cache directory available for Instagram download.");
+  const localUri = `${cacheDir}${fileName}`;
+
+  // IG CDN sometimes 403s without a referer, so set one
+  const download = await FileSystem.downloadAsync(imageUrl, localUri, {
+    headers: {
+      "User-Agent": DESKTOP_USER_AGENT,
+      Referer: "https://www.instagram.com/",
+    },
+  });
+  if (download.status !== 200) {
+    throw new Error(`Could not download the post image (HTTP ${download.status}).`);
+  }
+
+  return {
+    localUri: download.uri,
+    fileName,
+    mimeType: "image/jpeg",
+    caption,
+    author,
+    sourceUrl,
+  };
+}

--- a/supabase/migrations/20260521120000_memories_source_metadata.sql
+++ b/supabase/migrations/20260521120000_memories_source_metadata.sql
@@ -1,0 +1,12 @@
+-- Track where a memory came from when it was imported from an external post (e.g. Instagram share).
+-- Nullable across the board so existing camera-roll uploads keep working without changes.
+
+ALTER TABLE memories
+  ADD COLUMN IF NOT EXISTS source_url text,
+  ADD COLUMN IF NOT EXISTS source_author text,
+  ADD COLUMN IF NOT EXISTS source_platform text;
+
+-- handy when we later want to list everything a user pulled in from a given platform
+CREATE INDEX IF NOT EXISTS memories_source_platform_idx
+  ON memories (user_id, source_platform)
+  WHERE source_platform IS NOT NULL;


### PR DESCRIPTION
## Summary

You can now share a public Instagram post into Venn from the iOS or Android share sheet, the same way image sharing from Photos already worked. The app pulls the post's image and caption from its public OG tags, opens the existing upload modal with the caption pre-filled and an "From @author on Instagram" hint, then saves the memory along with the source URL and author so we can link back to the post later.

Also includes a small fix for the action tab where the chat input was getting blocked by the keyboard on iOS, because the KeyboardAvoidingView wasn't accounting for the bottom tab bar height.

## What changed

- iOS share extension activation rule and the Android intent filter now accept URLs and text in addition to images.
- New `lib/instagramImport.ts` does the OG tag scrape with a desktop User-Agent, parses out the caption and author handle, downloads the image to a local temp file, and runs the caption through a sanitizer that strips HTML entities, zero-width characters, non-breaking spaces, and the trailing ellipsis Instagram appends when it truncates.
- The share handler in `app/(tabs)/archive.tsx` now branches on payload type: image goes straight to the existing flow, URL routes through the importer, anything else is gracefully rejected with an alert.
- New nullable columns on `memories`: `source_url`, `source_author`, `source_platform`. Saved defensively via the same pattern as `want_to_do` so the upload still succeeds if the migration hasn't been applied yet on a given environment.
- Action tab keyboard fix uses `useBottomTabBarHeight()` as `keyboardVerticalOffset`.

## Things to know before reviewing

- Migration needs to be applied: `20260521120000_memories_source_metadata.sql`. Three new nullable columns on `memories`. Existing RLS policies cover them since RLS is row-scoped not column-scoped.
- Caption fetching is best-effort. Instagram truncates `og:description` to roughly 150 characters and a private or login-walled post returns a generic page with no caption. Both cases are handled. Carousels only save the first image and reels save the video thumbnail.
- The activation rule change is in `app.json` and the gitignored `ios/expo-sharing-extension/Info.plist`. The plist was hand-edited to match so an existing local checkout doesn't need a prebuild. Anyone doing a fresh prebuild will get the same rules from `app.json`.
- Tested end to end on a real iPhone via an EAS development build.

## Test plan

- [ ] Apply the migration in Supabase.
- [ ] Share a public Instagram post into Venn, confirm the caption modal opens with the caption pre-filled and the author hint above it.
- [ ] Save the memory and confirm `source_url`, `source_author`, `source_platform` are populated in the `memories` row.
- [ ] Share a private or removed Instagram post and confirm the "post may be private or unavailable" alert.
- [ ] Share a non-Instagram URL and confirm the "Venn can only import Instagram posts" alert.
- [ ] Open the action tab on iPhone, tap the chat input, confirm the keyboard no longer covers the field.