### PR TITLE
Calendar integration

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,12 @@
         }
       ],
       [
+        "expo-calendar",
+        {
+          "calendarPermission": "Venn opens a draft calendar event you can edit and save."
+        }
+      ],
+      [
         "expo-splash-screen",
         {
           "image": "./assets/images/splash-icon.png",

--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/lib/fetchMemoryThumbnailUrls";
 import { CHAT_PROMPTS, sendChatMessage } from "@/lib/chat";
 import {
+  type ChatTurn,
   type EventDraft,
   extractEventDraft,
   looksSchedulable,
@@ -18,7 +19,7 @@ import { Ionicons } from "@expo/vector-icons";
 import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import { useFocusEffect } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Image } from "expo-image";
 import { File } from "expo-file-system";
 import { ImageManipulator, SaveFormat } from "expo-image-manipulator";
@@ -130,6 +131,12 @@ export default function ActionTab() {
   const [savedMessageIds, setSavedMessageIds] = useState<Record<string, string>>({});
   const scrollRef = useRef<ScrollView>(null);
   const chatSessionId = useRef(`chat-${Date.now()}`).current;
+  // mirror of messages so async helpers (calendar extraction) read the latest history
+  // without forcing appendExchange's useCallback to re-create whenever messages change.
+  const messagesRef = useRef<ChatMessage[]>([]);
+  useEffect(() => {
+    messagesRef.current = messages;
+  }, [messages]);
   // the keyboard-avoiding view doesn't know about the tab bar, so the input ends up tucked
   // behind the keyboard. offsetting by the tab bar height lifts it the rest of the way
   const tabBarHeight = useBottomTabBarHeight();
@@ -254,6 +261,7 @@ export default function ActionTab() {
           : splitConvoBubbles(reply.text);
         const candidates = reply.memoryCandidates;
         const usedMemoryIdsThisReply = new Set<string>();
+        const bubblesSoFar: string[] = [];
         for (let i = 0; i < bubbles.length; i += 1) {
           if (i > 0) await new Promise((r) => setTimeout(r, 450));
           const text = bubbles[i];
@@ -263,7 +271,16 @@ export default function ActionTab() {
           for (const thumb of relatedLibraryImages) {
             usedMemoryIdsThisReply.add(thumb.memoryId);
           }
-          const schedulable = looksSchedulable(trimmed, text);
+          // Build the conversation history *including* the new user turn and the
+          // assistant bubbles produced in this same reply, so cross-turn references
+          // like "schedule it" can be resolved against earlier context.
+          const history: ChatTurn[] = [
+            ...messagesRef.current.map((m) => ({ role: m.role, text: m.text })),
+            { role: "user", text: trimmed },
+            ...bubblesSoFar.map((b) => ({ role: "assistant" as const, text: b })),
+            { role: "assistant", text },
+          ];
+          const schedulable = looksSchedulable(history);
           const draftMessage = makeMessage(
             "assistant",
             text,
@@ -272,10 +289,11 @@ export default function ActionTab() {
             schedulable ? "loading" : undefined
           );
           setMessages((m) => [...m, draftMessage]);
+          bubblesSoFar.push(text);
           requestAnimationFrame(() => scrollRef.current?.scrollToEnd({ animated: true }));
 
           if (schedulable) {
-            void extractEventDraft(trimmed, text)
+            void extractEventDraft(history)
               .then((draft) => {
                 setMessages((m) =>
                   m.map((existing) =>

--- a/app/(tabs)/action.tsx
+++ b/app/(tabs)/action.tsx
@@ -6,6 +6,12 @@ import {
   relatedThumbnailsForMessageText,
 } from "@/lib/fetchMemoryThumbnailUrls";
 import { CHAT_PROMPTS, sendChatMessage } from "@/lib/chat";
+import {
+  type EventDraft,
+  extractEventDraft,
+  looksSchedulable,
+  openEventInCalendar,
+} from "@/lib/chatCalendar";
 import { track } from "@/lib/posthog";
 import { removeSavedChatOutput, saveChatOutput, suggestSavedChatOutputTitle } from "@/lib/savedChatOutputs";
 import { Ionicons } from "@expo/vector-icons";
@@ -30,6 +36,8 @@ import {
 } from "react-native";
 import { SafeAreaView } from "react-native-safe-area-context";
 
+type EventDraftState = "loading" | EventDraft | null;
+
 type ChatMessage = {
   id: string;
   role: "user" | "assistant";
@@ -37,6 +45,8 @@ type ChatMessage = {
   imageUris?: string[];
   /** Library thumbnails when the reply overlaps saved memory OCR/captions */
   relatedLibraryImages?: RelatedMemoryThumbnail[];
+  /** Extracted calendar draft for assistant bubbles; "loading" while we're asking the model. */
+  eventDraft?: EventDraftState;
 };
 type SelectedImage = {
   uri: string;
@@ -171,15 +181,34 @@ export default function ActionTab() {
       role: "user" | "assistant",
       text: string,
       imageUris?: string[],
-      relatedLibraryImages?: RelatedMemoryThumbnail[]
+      relatedLibraryImages?: RelatedMemoryThumbnail[],
+      eventDraft?: EventDraftState
     ): ChatMessage => ({
       id: `${role}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
       role,
       text,
       imageUris,
       ...(relatedLibraryImages?.length ? { relatedLibraryImages } : {}),
+      ...(eventDraft !== undefined ? { eventDraft } : {}),
     }),
     []
+  );
+
+  const handleOpenInCalendar = useCallback(
+    async (msg: ChatMessage) => {
+      const draft = msg.eventDraft;
+      if (!draft || draft === "loading") return;
+      const outcome = await openEventInCalendar(draft);
+      track("chat_response_calendar_drafted", {
+        chat_session_id: chatSessionId,
+        message_id: msg.id,
+        outcome,
+      });
+      if (outcome === "error") {
+        Alert.alert("Calendar", "Could not open the calendar event editor.");
+      }
+    },
+    [chatSessionId]
   );
 
   const appendExchange = useCallback(
@@ -234,16 +263,38 @@ export default function ActionTab() {
           for (const thumb of relatedLibraryImages) {
             usedMemoryIdsThisReply.add(thumb.memoryId);
           }
-          setMessages((m) => [
-            ...m,
-            makeMessage(
-              "assistant",
-              text,
-              undefined,
-              relatedLibraryImages.length > 0 ? relatedLibraryImages : undefined
-            ),
-          ]);
+          const schedulable = looksSchedulable(trimmed, text);
+          const draftMessage = makeMessage(
+            "assistant",
+            text,
+            undefined,
+            relatedLibraryImages.length > 0 ? relatedLibraryImages : undefined,
+            schedulable ? "loading" : undefined
+          );
+          setMessages((m) => [...m, draftMessage]);
           requestAnimationFrame(() => scrollRef.current?.scrollToEnd({ animated: true }));
+
+          if (schedulable) {
+            void extractEventDraft(trimmed, text)
+              .then((draft) => {
+                setMessages((m) =>
+                  m.map((existing) =>
+                    existing.id === draftMessage.id
+                      ? { ...existing, eventDraft: draft ?? null }
+                      : existing
+                  )
+                );
+              })
+              .catch(() => {
+                setMessages((m) =>
+                  m.map((existing) =>
+                    existing.id === draftMessage.id
+                      ? { ...existing, eventDraft: null }
+                      : existing
+                  )
+                );
+              });
+          }
         }
       } catch (err) {
         setMessages((m) => [
@@ -447,7 +498,26 @@ export default function ActionTab() {
                         <AssistantMessageBody content={msg.text} />
                         <RelatedLibraryPhotos items={msg.relatedLibraryImages ?? []} />
                       </View>
-                      <View className="mt-2 flex-row justify-end gap-1">
+                      <View className="mt-2 flex-row items-center justify-end gap-1">
+                        {msg.eventDraft === "loading" ? (
+                          <View
+                            accessibilityRole="text"
+                            accessibilityLabel="Preparing calendar draft"
+                            className="h-8 w-8 items-center justify-center rounded-full"
+                          >
+                            <ActivityIndicator size="small" color="#8A8278" />
+                          </View>
+                        ) : msg.eventDraft ? (
+                          <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel="Add to calendar"
+                            hitSlop={8}
+                            onPress={() => void handleOpenInCalendar(msg)}
+                            className="h-8 w-8 items-center justify-center rounded-full active:bg-[#F0EBE3]"
+                          >
+                            <Ionicons name="calendar-outline" size={16} color="#0B7AEE" />
+                          </Pressable>
+                        ) : null}
                         <Pressable
                           accessibilityRole="button"
                           accessibilityLabel="Copy chat output"

--- a/lib/chatCalendar.ts
+++ b/lib/chatCalendar.ts
@@ -10,7 +10,13 @@
  */
 
 const EXTRACT_MODEL = "gpt-4.1-mini";
-const EXTRACT_MAX_TOKENS = 220;
+const EXTRACT_MAX_TOKENS = 260;
+/** Tail of recent turns fed into extraction. Keeps prompt cheap but resolves "schedule it" → earlier "Saturday". */
+const HISTORY_TURN_LIMIT = 10;
+/** Per-turn truncation so a single long reply can't blow the prompt. */
+const HISTORY_PER_TURN_CHARS = 600;
+
+export type ChatTurn = { role: "user" | "assistant"; text: string };
 
 export type EventDraft = {
   title: string;
@@ -31,10 +37,21 @@ const SCHEDULABLE_PATTERNS: RegExp[] = [
   /\b\d{1,2}:\d{2}\b/,
   /\b(today|tonight|tomorrow|this (?:weekend|week|morning|afternoon|evening|saturday|sunday|monday|tuesday|wednesday|thursday|friday))\b/i,
   /\b(next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday))\b/i,
+  /\b(great,? (?:let'?s|please) ?(?:schedule|book|do|plan)|sounds good,? schedule|do it|go ahead and (?:schedule|book|plan))\b/i,
 ];
 
-export function looksSchedulable(userText: string, assistantText: string): boolean {
-  const blob = `${userText}\n${assistantText}`.toLowerCase();
+/**
+ * Cheap pre-filter so we only burn an LLM call when the recent conversation looks event-like.
+ * Accepts the tail of the conversation (latest at the end) so phrases like "great, schedule it"
+ * still trigger even when the earlier turn was the one with the date.
+ */
+export function looksSchedulable(turns: ChatTurn[]): boolean {
+  if (!turns.length) return false;
+  const blob = turns
+    .slice(-HISTORY_TURN_LIMIT)
+    .map((t) => t.text)
+    .join("\n")
+    .toLowerCase();
   if (!blob.trim()) return false;
   return SCHEDULABLE_PATTERNS.some((re) => re.test(blob));
 }
@@ -86,10 +103,19 @@ function parseDraft(raw: unknown): EventDraft | null {
   };
 }
 
-export async function extractEventDraft(
-  userText: string,
-  assistantText: string
-): Promise<EventDraft | null> {
+function formatHistory(turns: ChatTurn[]): string {
+  const tail = turns.slice(-HISTORY_TURN_LIMIT);
+  return tail
+    .map((t) => {
+      const label = t.role === "user" ? "USER" : "ASSISTANT";
+      const body = t.text.replace(/\s+/g, " ").trim().slice(0, HISTORY_PER_TURN_CHARS);
+      return `${label}: ${body}`;
+    })
+    .join("\n");
+}
+
+export async function extractEventDraft(turns: ChatTurn[]): Promise<EventDraft | null> {
+  if (!turns.length) return null;
   const apiKey = process.env.EXPO_PUBLIC_OPENAI_API_KEY?.trim();
   if (!apiKey) return null;
 
@@ -99,19 +125,37 @@ export async function extractEventDraft(
   const nowLocal = now.toLocaleString(undefined, { dateStyle: "full", timeStyle: "short" });
 
   const system =
-    "You turn a short exchange between a user and a planning assistant into ONE actionable calendar event, " +
-    "or null if there is no concrete event to schedule. Pick a specific, editable time that makes sense " +
-    "(the user can change it). Prefer details the assistant or user mentioned; otherwise use reasonable defaults " +
-    "like tomorrow 6pm or this Saturday 10am.\n\n" +
-    "Return STRICT JSON only, matching this shape:\n" +
+    "You turn a recent chat conversation between a user and a planning assistant into ONE actionable " +
+    "calendar event, or null if there is nothing concrete to schedule. The result will pre-fill an " +
+    "editable native calendar draft; the user can adjust before saving.\n\n" +
+    "Rules:\n" +
+    " - Resolve relative date references across the whole conversation, not just the last turn. " +
+    "If the user said \"Saturday\" earlier and \"great, schedule it\" later, use that Saturday.\n" +
+    " - When no time-of-day is given, pick a sensible default for the activity:\n" +
+    "     hike / outdoor / nature / beach: weekend morning ~8\u201310am, duration 90\u2013120 min\n" +
+    "     brunch: weekend 10\u201311am, 75 min\n" +
+    "     lunch: weekday 12\u20131pm, 60 min\n" +
+    "     dinner / drinks: 6:30\u20138pm, 90 min\n" +
+    "     coffee / quick catch-up: weekday morning 9\u201310am or 3\u20134pm, 30\u201345 min\n" +
+    "     workout / gym / run: weekday 7am or 6pm, 60 min\n" +
+    "     doctor / dentist / appointment / meeting / call: weekday business hours 10am or 2pm, 30\u201360 min\n" +
+    "     movie / concert / show / event: evening 7\u20138pm, 120 min\n" +
+    "     birthday / party / hang / casual plan: weekend afternoon ~1pm, 120 min\n" +
+    "     unspecified leisure: upcoming Saturday 10am\n" +
+    " - Do NOT schedule outdoor or leisure activities Mon\u2013Fri 9am\u20135pm unless the conversation explicitly says weekday or work hours.\n" +
+    " - If a day was named without time (e.g. \"Saturday\"), keep that day, only choose the time.\n" +
+    " - Pick the next future occurrence in the user's local timezone.\n" +
+    " - location: include only if it appears verbatim in the conversation. notes: 1\u20132 short sentences summarizing the plan, or omit.\n" +
+    " - duration_minutes: integer between 15 and 240.\n\n" +
+    "Return STRICT JSON only:\n" +
     `{"event": {"title": string, "start_iso": ISO 8601 local time (e.g. 2026-05-28T19:00), ` +
-    `"duration_minutes": integer between 15 and 240, "location"?: string, "notes"?: string}}\n` +
-    `If there is nothing to schedule, return {"event": null}.`;
+    `"duration_minutes": integer 15\u2013240, "location"?: string, "notes"?: string}}\n` +
+    `If there is nothing concrete to schedule, return {"event": null}.`;
 
+  const history = formatHistory(turns);
   const user =
     `Now (user's local time): ${nowLocal} (${tz}); UTC: ${nowIso}.\n\n` +
-    `User said:\n"""${userText.slice(0, 1200)}"""\n\n` +
-    `Assistant said:\n"""${assistantText.slice(0, 2000)}"""`;
+    `Recent conversation (oldest first):\n${history}`;
 
   const body = {
     model: EXTRACT_MODEL,

--- a/lib/chatCalendar.ts
+++ b/lib/chatCalendar.ts
@@ -1,0 +1,189 @@
+/**
+ * Bridges chat replies to a native, editable calendar draft.
+ *
+ *  - looksSchedulable: cheap heuristic to decide whether to spend an LLM call on extraction
+ *  - extractEventDraft: OpenAI JSON call that resolves time / title / location
+ *  - openEventInCalendar: opens the OS calendar event editor with the draft pre-filled
+ *
+ * All entry points are fail-soft: if anything goes wrong, callers get null / "error"
+ * so the chat UI just hides the calendar button rather than crashing the message bubble.
+ */
+
+const EXTRACT_MODEL = "gpt-4.1-mini";
+const EXTRACT_MAX_TOKENS = 220;
+
+export type EventDraft = {
+  title: string;
+  /** Local ISO 8601, e.g. 2026-05-28T19:00. */
+  startIso: string;
+  durationMinutes: number;
+  location?: string;
+  notes?: string;
+};
+
+export type OpenInCalendarOutcome = "saved" | "canceled" | "deleted" | "done" | "error";
+
+const SCHEDULABLE_PATTERNS: RegExp[] = [
+  /\b(schedule|book|reserve|reschedul\w*|set up|add (?:to )?(?:my )?calendar|calendar invite|invite)\b/i,
+  /\b(remind me|put .* on (?:my )?calendar|plan(?:ning)? (?:to|on)|let'?s do|let'?s meet|meeting|appointment|appt|rsvp)\b/i,
+  /\b(mon|tue|tues|wed|thu|thur|thurs|fri|sat|sun)(?:day)?\b/i,
+  /\b\d{1,2}(?::\d{2})?\s?(?:am|pm)\b/i,
+  /\b\d{1,2}:\d{2}\b/,
+  /\b(today|tonight|tomorrow|this (?:weekend|week|morning|afternoon|evening|saturday|sunday|monday|tuesday|wednesday|thursday|friday))\b/i,
+  /\b(next (?:week|month|monday|tuesday|wednesday|thursday|friday|saturday|sunday))\b/i,
+];
+
+export function looksSchedulable(userText: string, assistantText: string): boolean {
+  const blob = `${userText}\n${assistantText}`.toLowerCase();
+  if (!blob.trim()) return false;
+  return SCHEDULABLE_PATTERNS.some((re) => re.test(blob));
+}
+
+function safeTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+function clampDuration(raw: unknown): number {
+  const n = typeof raw === "number" ? raw : typeof raw === "string" ? Number(raw) : NaN;
+  if (!Number.isFinite(n)) return 60;
+  return Math.min(240, Math.max(15, Math.round(n)));
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseDraft(raw: unknown): EventDraft | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  if (obj.event == null && obj.title == null) return null;
+  const source = (obj.event && typeof obj.event === "object" ? obj.event : obj) as Record<
+    string,
+    unknown
+  >;
+
+  const title = nonEmptyString(source.title);
+  const startIso = nonEmptyString(source.start_iso) ?? nonEmptyString(source.startIso);
+  if (!title || !startIso) return null;
+  if (Number.isNaN(Date.parse(startIso))) return null;
+
+  const duration = clampDuration(source.duration_minutes ?? source.durationMinutes);
+  const location = nonEmptyString(source.location);
+  const notes = nonEmptyString(source.notes);
+
+  return {
+    title,
+    startIso,
+    durationMinutes: duration,
+    ...(location ? { location } : {}),
+    ...(notes ? { notes } : {}),
+  };
+}
+
+export async function extractEventDraft(
+  userText: string,
+  assistantText: string
+): Promise<EventDraft | null> {
+  const apiKey = process.env.EXPO_PUBLIC_OPENAI_API_KEY?.trim();
+  if (!apiKey) return null;
+
+  const now = new Date();
+  const tz = safeTimezone();
+  const nowIso = now.toISOString();
+  const nowLocal = now.toLocaleString(undefined, { dateStyle: "full", timeStyle: "short" });
+
+  const system =
+    "You turn a short exchange between a user and a planning assistant into ONE actionable calendar event, " +
+    "or null if there is no concrete event to schedule. Pick a specific, editable time that makes sense " +
+    "(the user can change it). Prefer details the assistant or user mentioned; otherwise use reasonable defaults " +
+    "like tomorrow 6pm or this Saturday 10am.\n\n" +
+    "Return STRICT JSON only, matching this shape:\n" +
+    `{"event": {"title": string, "start_iso": ISO 8601 local time (e.g. 2026-05-28T19:00), ` +
+    `"duration_minutes": integer between 15 and 240, "location"?: string, "notes"?: string}}\n` +
+    `If there is nothing to schedule, return {"event": null}.`;
+
+  const user =
+    `Now (user's local time): ${nowLocal} (${tz}); UTC: ${nowIso}.\n\n` +
+    `User said:\n"""${userText.slice(0, 1200)}"""\n\n` +
+    `Assistant said:\n"""${assistantText.slice(0, 2000)}"""`;
+
+  const body = {
+    model: EXTRACT_MODEL,
+    temperature: 0.2,
+    max_tokens: EXTRACT_MAX_TOKENS,
+    response_format: { type: "json_object" },
+    messages: [
+      { role: "system", content: system },
+      { role: "user", content: user },
+    ],
+  };
+
+  let res: Response;
+  try {
+    res = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return null;
+  }
+  if (!res.ok) return null;
+
+  let json: { choices?: { message?: { content?: string } }[] };
+  try {
+    json = (await res.json()) as typeof json;
+  } catch {
+    return null;
+  }
+  const content = json.choices?.[0]?.message?.content?.trim();
+  if (!content) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    return null;
+  }
+
+  return parseDraft(parsed);
+}
+
+/**
+ * Opens the native calendar's event editor with the draft fields pre-filled.
+ * On iOS the user sees EKEventEditViewController; on Android the calendar app
+ * opens via intent. Either way the user picks the final calendar / invitees.
+ */
+export async function openEventInCalendar(draft: EventDraft): Promise<OpenInCalendarOutcome> {
+  try {
+    const Calendar = await import("expo-calendar");
+    const start = new Date(draft.startIso);
+    if (Number.isNaN(start.getTime())) return "error";
+    const end = new Date(start.getTime() + draft.durationMinutes * 60_000);
+
+    const result = await Calendar.createEventInCalendarAsync({
+      title: draft.title,
+      startDate: start,
+      endDate: end,
+      ...(draft.location ? { location: draft.location } : {}),
+      ...(draft.notes ? { notes: draft.notes } : {}),
+    });
+
+    const action = result?.action;
+    if (action === "saved" || action === "canceled" || action === "deleted" || action === "done") {
+      return action;
+    }
+    return "done";
+  } catch {
+    return "error";
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@supabase/supabase-js": "^2.104.0",
         "base64-arraybuffer": "^1.0.2",
         "expo": "~55.0.0",
+        "expo-calendar": "~55.0.15",
         "expo-constants": "~55.0.15",
         "expo-crypto": "~55.0.14",
         "expo-dev-client": "~55.0.30",
@@ -6909,6 +6910,16 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-calendar": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-calendar/-/expo-calendar-55.0.15.tgz",
+      "integrity": "sha512-JvHuqF56Y0nsFNaRdWn3WpcG3OMxt/1s+yImbH2AntBKqvXeObhoHF3uQYJWHJHZ25DlFI8hi9cGpKy5NO2m2w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
         "react-native": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@supabase/supabase-js": "^2.104.0",
     "base64-arraybuffer": "^1.0.2",
     "expo": "~55.0.0",
+    "expo-calendar": "~55.0.15",
     "expo-constants": "~55.0.15",
     "expo-crypto": "~55.0.14",
     "expo-dev-client": "~55.0.30",


### PR DESCRIPTION
Added chatbot button to export plan as calendar invite. Alters chatbot logic to automatically populate invite description, title, and time. Currently constrained to not schedule leisure/recreational activities during the weekdays 9-5pm, and otherwise chooses reasonable future estimates for times. Also increased context so that the bot can schedule the activity on the appropriate day / within any constraints specified earlier in the chat session.

Future prompt engineering needs to be done to improve the location specificity and activity specificity of the bot, and to avoid populating the schedule button before a single activity is selected by the user. 

https://github.com/user-attachments/assets/84ab8836-5883-436c-8f59-f28b0b0f85c1

